### PR TITLE
avoid unnecessary churn from ./dev/updatemessages.sh

### DIFF
--- a/dev/updatemessages.sh
+++ b/dev/updatemessages.sh
@@ -27,6 +27,10 @@ docker-compose exec app coverage run manage.py \
         --verbosity 2
 echo
 
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Django Management format_pofile'
+docker-compose exec app ./manage.py format_pofile locale
+echo
+
 printf "\e[1m\e[7m %-80s\e[0m\n" 'Django Managment compilemessages'
 docker-compose exec app coverage run manage.py \
     compilemessages

--- a/dev/updatemessages.sh
+++ b/dev/updatemessages.sh
@@ -3,12 +3,22 @@
 # Run Django Management nofuzzy_makemessages with helpful options (including
 # excluding legalcode) and compilemessages
 #
+set -o errexit
 set -o errtrace
 set -o nounset
 
 # Change directory to cc-legal-tools-app (grandparent directory of this script)
 cd ${0%/*}/../
 
+
+if command -v gsed >/dev/null; then
+    _sed=gsed
+elif sed --version >/dev/null; then
+    _sed=sed
+else
+    echo 'GNU sed is required. If on macOS install via `gnu-sed`' 1>&2
+    exit 1
+fi
 if ! docker-compose exec app true 2>/dev/null; then
     echo 'The app container/services is not avaialable.' 1>&2
     echo 'First run `docker-compose up`.' 1>&2
@@ -25,6 +35,22 @@ docker-compose exec app coverage run manage.py \
         --ignore **/includes/legalcode_zero.html \
         --no-obsolete \
         --verbosity 2
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Restore POT-Creation-Date'
+pushd ../cc-legal-tools-data/ >/dev/null
+for _pofile in $(git diff --name-only); do
+    [[ "${_pofile}" =~ django\.po$ ]] || continue
+    creation_old="$(git diff "${_pofile}" | grep '^-"POT-Creation-Date')"
+    creation_old="${creation_old:2:${#creation_old}-5}"
+    creation_new="$(git diff "${_pofile}" | grep '^+"POT-Creation-Date')"
+    creation_new="${creation_new:2:${#creation_new}-5}"
+    if [[ -n "${creation_old}" ]] && [[ -n "${creation_new}" ]]; then
+        echo "updating ${_pofile}"
+        gsed -e"s#${creation_new}#${creation_old}#" -i "${_pofile}"
+    fi
+done
+popd >/dev/null
 echo
 
 printf "\e[1m\e[7m %-80s\e[0m\n" 'Django Management format_pofile'


### PR DESCRIPTION
## Description
avoid unnecessary churn from `./dev/updatemessages.sh`
- reformat PO Files using polib for consistency
- revert creation date

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
