### PR TITLE
improve translation statistics CSV (app)

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -7,15 +7,6 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-CSV_HEADERS = [
-    "lang_ietf",
-    "lang_locale",
-    "num_messages",
-    "num_trans",
-    "num_fuzzy",
-    "percent_trans",
-]
-DEFAULT_INPUT_DIR = os.path.dirname(settings.DEEDS_UX_LOCALE_PATH)
 DEFAULT_CSV_FILE = os.path.abspath(
     os.path.realpath(os.path.join(settings.DISTILL_DIR, "transstats.csv"))
 )

--- a/i18n/management/commands/transstats.py
+++ b/i18n/management/commands/transstats.py
@@ -1,23 +1,17 @@
 """
-Statistics on the translations of this file.
-
-The CSV written will be in the format of:
-  lang,num_messages,num_trans,num_fuzzy,percent_trans
+Generate translations statistics CSV file.
 """
 
 # Standard library
-import csv
 import logging
 import os
 
 # Third-party
-import polib
-from django.conf import settings
 from django.core.management import BaseCommand
 
 # First-party/Local
-from i18n import CSV_HEADERS, DEFAULT_CSV_FILE, DEFAULT_INPUT_DIR
-from i18n.utils import get_pofile_path, map_django_to_transifex_language_code
+from i18n import DEFAULT_CSV_FILE
+from i18n.utils import write_transstats_csv
 
 LOG = logging.getLogger(__name__)
 LOG_LEVELS = {
@@ -28,77 +22,8 @@ LOG_LEVELS = {
 }
 
 
-def gen_statistics(input_dir, output_file):
-    """
-    Generate statistics on languages for how translated they are.
-
-    Keyword arguments:
-    - input_dir: The directory of languages we'll iterate through
-    - output_file: Path to the CSV file that will be written to
-    """
-    output_file = open(output_file, "w")
-
-    input_dir = os.path.abspath(os.path.realpath(input_dir))
-
-    # Create CSV writer
-    writer = csv.DictWriter(output_file, CSV_HEADERS, dialect="unix")
-    writer.writeheader()
-
-    # iterate through all the languages
-    for (
-        language_code,
-        language_data,
-    ) in settings.DEEDS_UX_PO_FILE_INFO.items():
-        if language_code == settings.LANGUAGE_CODE:
-            continue
-        transifex_code = map_django_to_transifex_language_code(language_code)
-        pofile_path = get_pofile_path(
-            locale_or_legalcode="locale",
-            language_code=language_code,
-            translation_domain="django",
-            data_dir=input_dir,
-        )
-
-        # load .po file
-        LOG.info(f"Reading {pofile_path}")
-        pofile_obj = polib.pofile(pofile_path)
-
-        fuzzies = 0
-        translated = 0
-
-        for entry in pofile_obj:
-            if entry.msgstr:
-                if entry.fuzzy:
-                    fuzzies += 1
-                else:
-                    translated += 1
-
-        writer.writerow(
-            {
-                "lang_ietf": language_code,
-                "lang_locale": transifex_code,
-                "num_messages": len(pofile_obj),
-                "num_trans": translated,
-                "num_fuzzy": fuzzies,
-                "percent_trans": int(
-                    (float(translated) / len(pofile_obj)) * 100
-                ),
-            }
-        )
-
-    output_file.close()
-
-
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument(
-            "-i",
-            "--input_dir",
-            dest="input_dir",
-            help="Directory to search for .po files to generate statistics"
-            f" on (default: {DEFAULT_INPUT_DIR})",
-            default=DEFAULT_INPUT_DIR,
-        )
         parser.add_argument(
             "-o",
             "--output_file",
@@ -108,8 +33,9 @@ class Command(BaseCommand):
             default=DEFAULT_CSV_FILE,
         )
 
-    def handle(self, *args, input_dir, output_file, **options):
+    def handle(self, *args, **options):
         LOG.setLevel(LOG_LEVELS[int(options["verbosity"])])
+        output_file = options["output_file"]
         if os.path.exists(output_file):
             os.remove(output_file)
-        gen_statistics(input_dir, output_file)
+        write_transstats_csv(output_file)

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 # Third-party
 import polib
+from django.conf import settings
 from dateutil.tz import tzutc
 from django.test import TestCase, override_settings
 
@@ -220,7 +221,7 @@ class PofileTestWithData(TestCase):
             ]
         )
         # Open Aragonese PO FILE, read lines, and close it
-        location = "/home/cc-legal-tools-data/locale/af"
+        location = f"{settings.DEEDS_UX_LOCALE_PATH}/af"
         mo.assert_has_calls(
             [
                 call(f"{location}/LC_MESSAGES/django.po", "rb"),
@@ -229,7 +230,7 @@ class PofileTestWithData(TestCase):
             ]
         )
         # Open Dutch PO FILE, read lines, and close it
-        location = "/home/cc-legal-tools-data/locale/nl"
+        location = f"{settings.DEEDS_UX_LOCALE_PATH}/nl"
         mo.assert_has_calls(
             [
                 call(f"{location}/LC_MESSAGES/django.po", "rb"),
@@ -238,7 +239,7 @@ class PofileTestWithData(TestCase):
             ]
         )
         # Open Aranese PO FILE, read lines, and close it
-        location = "/home/cc-legal-tools-data/locale/oc_Aranes"
+        location = f"{settings.DEEDS_UX_LOCALE_PATH}/oc_Aranes"
         mo.assert_has_calls(
             [
                 call(f"{location}/LC_MESSAGES/django.po", "rb"),
@@ -247,7 +248,7 @@ class PofileTestWithData(TestCase):
             ]
         )
         # Open Serbian (Latin) PO FILE, read lines, and close it
-        location = "/home/cc-legal-tools-data/locale/sr_Latn"
+        location = f"{settings.DEEDS_UX_LOCALE_PATH}/sr_Latn"
         mo.assert_has_calls(
             [
                 call(f"{location}/LC_MESSAGES/django.po", "rb"),
@@ -256,7 +257,7 @@ class PofileTestWithData(TestCase):
             ]
         )
         # Open Chinese (Traditional) PO FILE, read lines, and close it
-        location = "/home/cc-legal-tools-data/locale/zh_Hant"
+        location = f"{settings.DEEDS_UX_LOCALE_PATH}/zh_Hant"
         mo.assert_has_calls(
             [
                 call(f"{location}/LC_MESSAGES/django.po", "rb"),

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 # Third-party
 import polib
-from django.conf import settings
 from dateutil.tz import tzutc
+from django.conf import settings
 from django.test import TestCase, override_settings
 
 # First-party/Local

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -23,6 +23,7 @@ from i18n.utils import (
     map_legacy_to_django_language_code,
     parse_date,
     save_content_as_pofile_and_mofile,
+    write_transstats_csv,
 )
 
 TEST_POFILE = os.path.join(
@@ -116,7 +117,7 @@ class TranslationTest(TestCase):
 
 
 @override_settings(DATA_REPOSITORY_DIR="/foo/bar")
-class PofileTest(TestCase):
+class PofileTestSimple(TestCase):
     def test_get_pofile_path(self):
         locale_path = get_pofile_path(
             locale_or_legalcode="locale",
@@ -197,6 +198,74 @@ class PofileTest(TestCase):
         pofile = mock_polib.pofile.return_value
         pofile.save.assert_called_with(path)
         pofile.save_as_mofile.assert_called_with("/foo/bar.mo")
+
+
+class PofileTestWithData(TestCase):
+    def test_write_transstats_csv(self):
+        output_file = "TESTFILE"
+
+        with mock.patch("builtins.open", mock.mock_open()) as mo:
+            write_transstats_csv(output_file)
+
+        call = mock.call
+        # Open output file and write CSV headers
+        mo.assert_has_calls(
+            [
+                call(output_file, "w"),
+                call().__enter__(),
+                call().write(
+                    '"lang_django","lang_locale","lang_transifex",'
+                    '"num_messages","num_trans","num_fuzzy","percent_trans"\n'
+                ),
+            ]
+        )
+        # Open Aragonese PO FILE, read lines, and close it
+        location = "/home/cc-legal-tools-data/locale/af"
+        mo.assert_has_calls(
+            [
+                call(f"{location}/LC_MESSAGES/django.po", "rb"),
+                call().readlines(),
+                call().close(),
+            ]
+        )
+        # Open Dutch PO FILE, read lines, and close it
+        location = "/home/cc-legal-tools-data/locale/nl"
+        mo.assert_has_calls(
+            [
+                call(f"{location}/LC_MESSAGES/django.po", "rb"),
+                call().readlines(),
+                call().close(),
+            ]
+        )
+        # Open Aranese PO FILE, read lines, and close it
+        location = "/home/cc-legal-tools-data/locale/oc_Aranes"
+        mo.assert_has_calls(
+            [
+                call(f"{location}/LC_MESSAGES/django.po", "rb"),
+                call().readlines(),
+                call().close(),
+            ]
+        )
+        # Open Serbian (Latin) PO FILE, read lines, and close it
+        location = "/home/cc-legal-tools-data/locale/sr_Latn"
+        mo.assert_has_calls(
+            [
+                call(f"{location}/LC_MESSAGES/django.po", "rb"),
+                call().readlines(),
+                call().close(),
+            ]
+        )
+        # Open Chinese (Traditional) PO FILE, read lines, and close it
+        location = "/home/cc-legal-tools-data/locale/zh_Hant"
+        mo.assert_has_calls(
+            [
+                call(f"{location}/LC_MESSAGES/django.po", "rb"),
+                call().readlines(),
+                call().close(),
+            ]
+        )
+        # Exit without failures
+        mo.assert_has_calls([call().__exit__(None, None, None)])
 
 
 class MappingTest(TestCase):
@@ -323,104 +392,3 @@ class MappingTest(TestCase):
 
         transifex_code = map_legacy_to_django_language_code("zh_Hans")
         self.assertEqual("zh-hans", transifex_code)
-
-
-# Disabled tests (Do not belong under class MappingTest)
-
-# def test_ugettext_for_locale(self):
-#     ugettext_en = ugettext_for_locale("en")
-#     ugettext_fr = ugettext_for_locale("fr")
-#
-#     # Need something translated already in Django
-#     msg_en = "That page contains no results"
-#     msg_fr = "Cette page ne contient aucun résultat"
-#     self.assertEqual(msg_en, ugettext_en(msg_en))
-#     self.assertEqual(msg_fr, ugettext_fr(msg_en))
-#
-# def test_get_well_translated_langs(self):
-#     dirname = os.path.dirname(__file__)
-#     filepath = os.path.join(dirname, "testdata.csv")
-#     result = get_well_translated_langs(
-#         threshold=settings.TRANSLATION_THRESHOLD,
-#         trans_file=filepath,
-#         append_english=False,
-#     )
-#     self.assertEqual([], result)
-#     result = get_well_translated_langs(
-#         threshold=settings.TRANSLATION_THRESHOLD,
-#         trans_file=filepath,
-#         append_english=True,
-#     )
-#     self.assertEqual([{"code": "en", "name": "English"}], result)
-#     result = get_well_translated_langs(
-#         threshold=1, trans_file=filepath, append_english=True
-#     )
-#     # Alphabetized
-#     self.assertEqual(
-#         [
-#             {"code": "en", "name": "English"},
-#             {"code": "fr", "name": "français"},
-#         ],
-#         result,
-#     )
-#
-# def test_get_all_trans_stats(self):
-#     from i18n.utils import CACHED_TRANS_STATS
-#
-#     CACHED_TRANS_STATS.clear()
-#
-#     with self.subTest("Uses cached result"):
-#         CACHED_TRANS_STATS["unused filename"] = "ding dong"
-#         self.assertEqual(
-#             "ding dong", get_all_trans_stats("unused filename")
-#         )
-#         CACHED_TRANS_STATS.clear()
-#
-#     with self.subTest("Nonexistent file raises exception"):
-#         with self.assertRaises(IOError):
-#             get_all_trans_stats("no such filename here")
-#
-#     with self.subTest("reads CSV file"):
-#         dirname = os.path.dirname(__file__)
-#         filepath = os.path.join(dirname, "testdata.csv")
-#         result = get_all_trans_stats(filepath)
-#         self.assertEqual(
-#             {
-#                 "fr": {
-#                     "num_messages": 222,
-#                     "num_trans": 13,
-#                     "num_fuzzy": 7,
-#                     "num_untrans": 202,
-#                     "percent_trans": 75,
-#                 }
-#             },
-#             result,
-#         )
-
-# def test_applicable_langs(self):
-#     from i18n.utils import CACHED_APPLICABLE_LANGS
-#
-#     CACHED_APPLICABLE_LANGS.clear()
-#
-#     with self.subTest("uses cached result"):
-#         cache_key = ("foobar",)
-#         CACHED_APPLICABLE_LANGS[cache_key] = ["bizzle"]
-#         self.assertEqual(["bizzle"], applicable_langs("foobar"))
-#         CACHED_APPLICABLE_LANGS.clear()
-#
-#     # Should always include "en". Does NOT cache that result.
-#     with self.subTest("always includes 'en'"):
-#         self.assertEqual(["en"], applicable_langs("no such locale"))
-#         self.assertNotIn(("en",), CACHED_APPLICABLE_LANGS)
-#
-#     with self.subTest("Just the language works"):
-#         locale = "fr"
-#         self.assertEqual(["fr", "en"], applicable_langs(locale))
-#         self.assertIn((locale,), CACHED_APPLICABLE_LANGS)
-#         CACHED_APPLICABLE_LANGS.clear()
-#
-#     with self.subTest("adding the territory works too"):
-#         locale = "es_ES"
-#         self.assertEqual(["es_ES", "es", "en"], applicable_langs(locale))
-#         self.assertIn((locale,), CACHED_APPLICABLE_LANGS)
-#         CACHED_APPLICABLE_LANGS.clear()

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -1,4 +1,5 @@
 # Standard library
+import csv
 import os
 import re
 from contextlib import contextmanager
@@ -337,13 +338,8 @@ def get_jurisdiction_name(category, unit, version, jurisdiction_code):
     return jurisdiction_name
 
 
-def load_deeds_ux_translations():
-    """
-    Process Deed & UX translations (store information on all and track those
-    that meet or exceed the TRANSLATION_THRESHOLD).
-    """
-    deeds_ux_po_file_info = {}
-    languages_mostly_translated = []
+def get_deeds_ux_pofiles():
+    deed_ux_pofiles = []
     for locale_name in os.listdir(settings.DEEDS_UX_LOCALE_PATH):
         language_code = translation.to_language(locale_name)
         pofile_path = get_pofile_path(
@@ -353,6 +349,19 @@ def load_deeds_ux_translations():
         )
         if not os.path.isfile(pofile_path):  # pragma: no cover
             continue
+        deed_ux_pofiles.append([language_code, pofile_path])
+    deed_ux_pofiles.sort(key=lambda x: x[0])
+    return deed_ux_pofiles
+
+
+def load_deeds_ux_translations():
+    """
+    Process Deed & UX translations (store information on all and track those
+    that meet or exceed the TRANSLATION_THRESHOLD).
+    """
+    deeds_ux_po_file_info = {}
+    languages_mostly_translated = []
+    for language_code, pofile_path in get_deeds_ux_pofiles():
         pofile_obj = polib.pofile(pofile_path)
         percent_translated = pofile_obj.percent_translated()
         deeds_ux_po_file_info[language_code] = {
@@ -397,159 +406,42 @@ def update_lang_info(language_code):
         pass
 
 
-# def ugettext_for_locale(locale):
-#     def _wrapped_ugettext(message):
-#         with override(locale):
-#             return force_text(ugettext(message))
-#
-#     return _wrapped_ugettext
-#
-#
-# def get_well_translated_langs(
-#     threshold=settings.TRANSLATION_THRESHOLD,
-#     trans_file=DEFAULT_CSV_FILE,
-#     append_english=True,
-# ):
-#     """
-#     Get an alphebatized and name-rendered list of all languages above
-#     a certain threshold of translation.
-#
-#     Keyword arguments:
-#     - threshold: percentage that languages should be translated at or above
-#     - trans_file: specify from which CSV file we're gathering statistics.
-#         Used for testing, You probably don't need this.
-#     - append_english: Add English to the list, even if it's completely
-#         "untranslated" (since English is the default for messages,
-#         nobody translates it)
-#
-#     Returns:
-#       An alphebatized sequence of dicts, where each element consists
-#       of the following keys:
-#        - code: the language code
-#        - name: the translated name of this language
-#       for each available language.
-#       An unsorted set of all qualified language codes
-#     """
-#     cache_key = (threshold, trans_file, append_english)
-#
-#     if cache_key in CACHED_WELL_TRANSLATED_LANGS:
-#         return CACHED_WELL_TRANSLATED_LANGS[cache_key]
-#
-#     trans_stats = get_all_trans_stats(trans_file)
-#
-#     qualified_langs = set(
-#         [
-#             lang
-#             for lang, data in trans_stats.items()
-#             if data["percent_trans"] >= threshold
-#         ]
-#     )
-#
-#     # Add english if necessary.
-#     if "en" not in qualified_langs and append_english:
-#         qualified_langs.add("en")
-#
-#     # this loop is long hand for clarity; it's only done once, so
-#     # the additional performance cost should be negligible
-#     result = []
-#
-#     for code in qualified_langs:
-#         # Come up with names for languages in their own languages
-#         gettext = ugettext_for_locale(code)
-#         if code in mappers.LANG_MAP:
-#             # we (should) have a translation for this name...
-#             name = gettext(mappers.LANG_MAP[code])
-#             result.append(dict(code=code, name=name))
-#
-#     result = sorted(result, key=lambda lang: lang["name"].lower())
-#
-#     CACHED_WELL_TRANSLATED_LANGS[cache_key] = result
-#
-#     return result
+def write_transstats_csv(output_file):
+    csv_headers = [
+        "lang_django",
+        "lang_locale",
+        "lang_transifex",
+        "num_messages",
+        "num_trans",
+        "num_fuzzy",
+        "percent_trans",
+    ]
 
+    with open(output_file, "w") as output_file:
+        # Create CSV writer
+        writer = csv.DictWriter(output_file, csv_headers, dialect="unix")
+        writer.writeheader()
 
-# CACHED_TRANS_STATS = {}
-#
-#
-# def get_all_trans_stats(trans_file=DEFAULT_CSV_FILE):
-#     """
-#     Get all of the statistics on all translations, how much they are done
-#
-#     Keyword arguments:
-#     - trans_file: specify from which CSV file we're gathering statistics.
-#         Used for testing, You probably don't need this.
-#
-#     Returns:
-#       A dictionary of dictionaries formatted like:
-#       {'no': {  # key is the language name
-#          'num_messages': 564,  # number of messages, total
-#          'num_trans': 400,  # number of messages translated
-#          'num_fuzzy': 14,  # number of fuzzy messages
-#          'num_untrans': 150,  # number of untranslated, non-fuzzy messages
-#          'percent_trans': 70},  # percentage of file translated
-#        [...]}
-#     """
-#     # return cached statistics, if available
-#     if trans_file in CACHED_TRANS_STATS:
-#         return CACHED_TRANS_STATS[trans_file]
-#
-#     if not os.path.exists(trans_file):
-#         raise IOError(
-#             f"No such CSV file {trans_file}. Maybe run"
-#             " `python manage.py transstats`?"
-#         )
-#
-#     reader = csv.DictReader(open(trans_file, "r"), CSV_HEADERS)
-#     stats = {}
-#
-#     # record statistics
-#     for line in reader:
-#         num_messages = int(line["num_messages"])
-#         num_trans = int(line["num_trans"])
-#         num_fuzzy = int(line["num_fuzzy"])
-#         num_untrans = num_messages - num_trans - num_fuzzy
-#         percent_trans = int(line["percent_trans"])
-#
-#         stats[line["lang"]] = {
-#             "num_messages": num_messages,
-#             "num_trans": num_trans,
-#             "num_fuzzy": num_fuzzy,
-#             "num_untrans": num_untrans,
-#             "percent_trans": percent_trans,
-#         }
-#
-#     # cache and return
-#     CACHED_TRANS_STATS[trans_file] = stats
-#     return stats
+        # Load PO Files and write a row for each
+        for language_code, pofile_path in get_deeds_ux_pofiles():
+            locale_name = translation.to_locale(language_code)
+            transifex_code = map_django_to_transifex_language_code(
+                language_code
+            )
 
+            pofile_obj = polib.pofile(pofile_path)
+            translated = len(pofile_obj.translated_entries())
+            fuzzy = len(pofile_obj.fuzzy_entries())
+            percent_translated = pofile_obj.percent_translated()
 
-# def applicable_langs(locale):
-#     """
-#     Return all available languages "applicable" to a requested locale.
-#     """
-#     cache_key = (locale,)
-#     if cache_key in CACHED_APPLICABLE_LANGS:
-#         return CACHED_APPLICABLE_LANGS[cache_key]
-#
-#     mo_path = settings.LOCALE_PATHS[0]
-#
-#     applicable_langs = []
-#     if os.path.exists(os.path.join(mo_path, locale)):
-#         applicable_langs.append(locale)
-#
-#     if "_" in locale:
-#         root_lang = locale.split("_")[0]
-#         if os.path.exists(os.path.join(mo_path, root_lang)):
-#             applicable_langs.append(root_lang)
-#
-#     if "en" not in applicable_langs:
-#         applicable_langs.append("en")
-#
-#     # Don't cache silly languages that only fallback to en anyway, to
-#     # (semi-)prevent caching infinite amounts of BS
-#     if not locale == "en" and len(applicable_langs) == 1:
-#         print("Not caching result")
-#         return applicable_langs
-#
-#     CACHED_APPLICABLE_LANGS[cache_key] = applicable_langs
-#     return applicable_langs
+            writer.writerow(
+                {
+                    "lang_django": language_code,
+                    "lang_locale": locale_name,
+                    "lang_transifex": transifex_code,
+                    "num_messages": len(pofile_obj),
+                    "num_trans": translated,
+                    "num_fuzzy": fuzzy,
+                    "percent_trans": percent_translated,
+                }
+            )

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -14,6 +14,8 @@ from django.http.response import Http404
 from django.urls import reverse
 
 # First-party/Local
+from i18n import DEFAULT_CSV_FILE
+from i18n.utils import write_transstats_csv
 from legal_tools.git_utils import commit_and_push_changes, setup_local_branch
 from legal_tools.models import LegalCode, TranslationBranch
 from legal_tools.utils import (
@@ -319,6 +321,10 @@ class Command(BaseCommand):
             copyfile(os.path.join(plaintext_dir, text), dest_file)
             LOG.debug(f"    {relative_name}")
 
+    def run_write_transstats_csv(self):
+        LOG.info("Generating translations statistics CSV")
+        write_transstats_csv(DEFAULT_CSV_FILE)
+
     def distill_and_copy(self):
         self.run_clean_output_dir()
         self.run_create_robots_txt()
@@ -326,6 +332,7 @@ class Command(BaseCommand):
         self.run_copy_tools_rdfs()
         self.run_copy_meta_rdfs()
         self.run_copy_legal_code_plaintext()
+        self.run_write_transstats_csv()
 
     def publish_branch(self, branch: str):
         """Workflow for publishing a single branch"""


### PR DESCRIPTION
## Fixes
Fixes #177 
- #177 

## Description
- Move generation of translation statistics CSV to `i18n.utils` and include in `publish` command
- Remove unused and commented out code

also see data PR: [improve translation statistics CSV (data) by TimidRobot · Pull Request #58 · creativecommons/cc-legal-tools-data](https://github.com/creativecommons/cc-legal-tools-data/pull/58)

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1347      0    492      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
