### PR TITLE
Complete xu removal (app)

### DIFF
--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -234,9 +234,6 @@ class Command(BaseCommand):
             else:
                 continue
             relative_name = os.path.join(*name.split("_"), "rdf")
-            # "xu" is a "user assigned code" meaning "unported"
-            # See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements.  # noqa: E501
-            relative_name = relative_name.replace("xu/", "")
             dest_file = os.path.join(output_dir, relative_name)
             os.makedirs(os.path.dirname(dest_file), exist_ok=True)
             copyfile(os.path.join(tools_rdf_dir, rdf), dest_file)

--- a/legal_tools/utils.py
+++ b/legal_tools/utils.py
@@ -27,13 +27,13 @@ def init_utils_logger(logger: logging.Logger = None):
         LOG = logger
 
 
-def save_bytes_to_file(bytes, output_filename):
+def save_bytes_to_file(filebytes, output_filename):
     dirname = os.path.dirname(output_filename)
     if os.path.isfile(dirname):
         os.remove(dirname)
     os.makedirs(dirname, mode=0o755, exist_ok=True)
-    with open(output_filename, "wb") as f:
-        f.write(bytes)  # Bytes
+    with open(output_filename, "w+b") as f:
+        f.write(filebytes)
 
 
 class MockRequest:
@@ -68,7 +68,6 @@ def relative_symlink(src1, src2, dst):
     padding = " " * len(os.path.dirname(src2))
     src = os.path.abspath(os.path.join(src1, src2))
     dir_path, src_file = os.path.split(src)
-    # Handle ../symlinks for xu jurisdiction
     if dst.startswith("../"):
         __, dst = os.path.split(dst)
         os.path.split(src2)


### PR DESCRIPTION
## Description
Complete `xu` removal (app):
- remove special handling of legacy RDF with `xu` jurisdiction 
- improve `save_bytes_to_file()`
  - do not use reserved word for variable name
  - write with truncation

see related data PR: [Complete xu removal (data) by TimidRobot · Pull Request #62 · creativecommons/cc-legal-tools-data](https://github.com/creativecommons/cc-legal-tools-data/pull/62)

## Technical details
- `xu` was a "user assigned code" meaning "unported"
  - [User-assigned code elements - ISO 3166-1 alpha-2 - Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements)
- 2020-09-12 (merged 2020-09-12): support for paths containing `xu` was added in [Move static files by dpoirier · Pull Request #68 · creativecommons/cc-legal-tools-app](https://github.com/creativecommons/cc-legal-tools-app/pull/68), at my request
- 2021-07-15 (merged 2021-07-16): support for paths containing `xu` was mostly removed in [remove "xu" and supporting symlinks from unported publish path by TimidRobot · Pull Request #134 · creativecommons/cc-legal-tools-app](https://github.com/creativecommons/cc-legal-tools-app/pull/134))

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1347      0    492      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
