### PR TITLE
HTML metadata clean-up (app)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,15 +4,17 @@
 {% get_current_language as LANGUAGE_CODE %}
 {% get_language_info for LANGUAGE_CODE as lang %}
 <html lang="{{ lang.code }}" dir="{% if lang.bidi %}rtl{% else %}ltr{% endif %}">
-<head about="{% block canonical_url %} {% endblock %}">
-  <meta charset="utf-8">
+<head about="{% block head_about %}{% endblock %}">
+  <meta charset="utf-8"/>
   <title>{% block title %}{% endblock %}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="{% block meta-description %}{% endblock %}">
-  <meta name="author" content="{% block meta-author %}{% endblock %}">
-  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
-  <meta name="keywords" content="{% block meta-keywords %}{% endblock %}">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
+  <meta name="CC-Canonical-URL" content="{% block tool_canonical_url %}{% endblock %}"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  {% block head_meta %}
+  {% endblock %}
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css"
+  />
   <link
     rel="stylesheet"
     href="https://unpkg.com/@creativecommons/fonts@2020.9.3/css/fonts.css"
@@ -28,7 +30,7 @@
   <!-- Import the Component Library via CDN -->
   <script src="https://unpkg.com/@creativecommons/cc-global-components@0.x.x/dist/cc-globals.min.js"></script>
 </head>
-<body typeoff="cc:License">
+<body typeof="{% block body_typeof %}{% endblock %}" about="{% block body_about %}{% endblock %}">
   {% include 'includes/header.html' %}
   <main>
     <div class="level padding-{% bidi_start %}-big padding-{% bidi_end %}-large padding-vertical-normal">

--- a/templates/deed.html
+++ b/templates/deed.html
@@ -1,8 +1,14 @@
 {% extends "base.html" %}
 {% load i18n static %}
 
-{% block canonical_url %}{{ tool.canonical_url }}{% endblock %}
+{% block head_about %}{{ tool.canonical_url }}{% endblock %}
 {% block title %}{{ legal_code.title }} Deed &mdash; Creative Commons{% endblock %}
+{% block tool_canonical_url %}{{ tool.canonical_url }}{% endblock %}
+{% block head_meta %}
+  <link rel="canonical" href="{{ tool.canonical_url }}"/>
+{% endblock %}
+{% block body_about %}{{ tool.canonical_url }}{% endblock %}
+{% block body_typeof %}cc:License{% endblock %}
 
 {% block active-breadcrumb-li %}
 <li class="is-active"><a href="{{ legal_code.deed_url }}" aria-current="page displayed">{{ legal_code.identifier }} {% trans "Deed" %}</a></li>
@@ -49,6 +55,5 @@
     border-right: 5px solid rgb(176, 176, 176);
   }
 </style>
-
 {% endblock %}
 {# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}

--- a/templates/legalcode.html
+++ b/templates/legalcode.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% load bidi i18n static %}
 
+{% block title %}{{ legal_code.title }} Legal Code &mdash; Creative Commons{% endblock %}
+{% block tool_canonical_url %}{{ tool.canonical_url }}{% endblock %}
+
 {% block active-breadcrumb-li %}
   <li class="is-active"><a href="{{ legal_code.legal_code_url }}" aria-current="page displayed">{{ legal_code.identifier }} {% trans "Legal Code" %}</a></li>
 {% endblock %}
@@ -22,8 +25,6 @@
   </div>
 </div>
 {% endblock %}
-
-{% block title %}{{ legal_code.title }} Legal Code &mdash; Creative Commons{% endblock %}
 
 {% block content %}
   <div class="columns">
@@ -58,7 +59,6 @@
       {% include 'includes/related_links.html' with show_legal_code=True %}
     </div>
   </div>
-
 
 <style>
   #legal-code-body {
@@ -109,7 +109,6 @@
         this.parentNode.parentNode.nextSibling.nextSibling.classList.add("is-hidden");
       }
     };
-
   </script>
 {% endblock %}
 {# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}


### PR DESCRIPTION
## Description
HTML metadata clean-up (app)
- add meta CC-Canonical-URL to Deeds & Legal Code
- add body about to Deeds
- add link rel canonical to Deeds
- correct body typeof spelling
- remove meta Content-Type
  - redundant with meta charset
  - innaccurate: pages are HTML5
- remove unused meta author
- remove unused meta description
- remove unused meta keywords
- remove unused meta viewport

also see related data PR: [HTML metadata clean-up (data) by TimidRobot · Pull Request #68 · creativecommons/cc-legal-tools-data](https://github.com/creativecommons/cc-legal-tools-data/pull/68)

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1347      0    492      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
