### PR TITLE
app: improve language/translation selection in published files

### DIFF
--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -169,6 +169,7 @@ def view_dev_index(request):
     # heads = repo.remotes.origin.refs
     # branches = [head.name[len("origin/") :] for head in heads]
 
+    translation.activate(settings.LANGUAGE_CODE)
     distilling = request.GET.get("distilling", False)
 
     # ensure translation status is current
@@ -224,7 +225,6 @@ def view_dev_index(request):
             "transifex_code": transifex_code,
         }
 
-    translation.activate(settings.LANGUAGE_CODE)
     html_response = render(
         request,
         template_name="dev/index.html",
@@ -254,6 +254,7 @@ def view_list(request, category, language_code=None):
     )
     if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
         raise Http404(f"invalid language: {language_code}")
+    translation.activate(language_code)
     # Get the list of units and languages that occur among the tools
     # to let the template iterate over them as it likes.
     legal_code_objects = (
@@ -323,7 +324,6 @@ def view_list(request, category, language_code=None):
         request_path=request.path,
         selected_language_code=language_code,
     )
-    translation.activate(language_code)
     html_response = render(
         request,
         template_name="list.html",
@@ -356,6 +356,7 @@ def view_deed(
     )
     if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
         raise Http404(f"invalid language: {language_code}")
+    translation.activate(language_code)
 
     path_start = os.path.dirname(request.path)
     language_default = get_default_language_for_jurisdiction(jurisdiction)
@@ -422,7 +423,6 @@ def view_deed(
     else:
         body_template = "includes/deed_body_unimplemented.html"
 
-    translation.activate(language_code)
     html_response = render(
         request,
         template_name="deed.html",


### PR DESCRIPTION
## Fixes
Fixes #243
- #243 

## Description
app: improve language/translation selection in published files
- activate language sooner in views

also see data PR: https://github.com/creativecommons/cc-legal-tools-data/pull/82

## Technical details
- [Translation | Django documentation | Django](https://docs.djangoproject.com/en/3.2/topics/i18n/translation/)

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1374      0    492      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
