### PR TITLE
app: use content class for "crude html" legal code

### DIFF
--- a/templates/includes/legalcode_crude_html.html
+++ b/templates/includes/legalcode_crude_html.html
@@ -1,6 +1,6 @@
 {# For tools that are only partially supported, we've just stored their HTML in the database. #}
 <div id="legal-code-body" class="padding-larger margin-top-bigger has-text-black">
-  <div id="plain-text-marker">
+  <div id="plain-text-marker" class="content">
     <h3 class="padding-bottom-normal b-header">{{ legal_code.title }}</h3>
     {{ legal_code.html|safe }}
   </div>{# end plain-text-marker #}


### PR DESCRIPTION
## Description
app: use `content` class for "crude html" legal code
- mitigates, but does not fix the following issue:
  - https://github.com/creativecommons/vocabulary/issues/1037

also see data PR: https://github.com/creativecommons/cc-legal-tools-data/pull/85

## Technical details
- https://github.com/creativecommons/vocabulary/issues/1037
  - https://github.com/jgthms/bulma/issues/2553
  - [Content | Bulma: Free, open source, and modern CSS framework based on Flexbox](https://bulma.io/documentation/elements/content/)

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1374      0    492      0   100.00%

19 files skipped due to complete coverage.
```

## Screenshots
### Old/Current
![Screenshot 2022-02-18 at 08-37-12 Attribution 3 0 Hong Kong Legal Code — Creative Commons](https://user-images.githubusercontent.com/691322/154724512-55ea55c6-6a55-4bcf-89a4-efa10f3a5ad2.png)

### New/PR
![Screenshot 2022-02-18 at 08-37-23 Attribution 3 0 Hong Kong Legal Code — Creative Commons](https://user-images.githubusercontent.com/691322/154724535-f4e6f0b2-912b-4278-af4c-07374d51b686.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
