### PR TITLE
App: fix legal code translations

### DIFF
--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -187,8 +187,8 @@ class TranslationTest(TestCase):
                 "i18n.utils.translation.trans_real.translation"
             ) as mock_trans:
                 result = get_translation_object(
-                    django_language_code="LANGUAGE_CODE",
                     domain="GETTEXT_DOMAIN",
+                    language_code="LANGUAGE_CODE",
                     language_default="LANGUAGE_DEFAULT",
                 )
         mock_djt.assert_called_with(
@@ -214,8 +214,8 @@ class TranslationTest(TestCase):
                 "i18n.utils.translation.trans_real.translation"
             ) as mock_trans:
                 result = get_translation_object(
-                    django_language_code="LANGUAGE_CODE",
                     domain="GETTEXT_DOMAIN",
+                    language_code="LANGUAGE_CODE",
                     language_default="LANGUAGE_DEFAULT",
                 )
         mock_djt.assert_called_with(
@@ -241,8 +241,8 @@ class TranslationTest(TestCase):
                 "i18n.utils.translation.trans_real.translation"
             ) as mock_trans:
                 result = get_translation_object(
-                    django_language_code="LANGUAGE_CODE",
                     domain="GETTEXT_DOMAIN",
+                    language_code="LANGUAGE_CODE",
                     language_default="LANGUAGE_DEFAULT",
                 )
         mock_djt.assert_called_with(

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -172,7 +172,11 @@ class I18NTest(TestCase):
 
 
 class TranslationTest(TestCase):
-    def test_get_translation_object(self):
+    @override_settings(
+        LANGUAGES_MOSTLY_TRANSLATED=["LANGUAGE_CODE"],
+        LEGAL_CODE_LOCALE_PATH="LOCALE_DIRS",
+    )
+    def test_get_translation_object_specified_translated(self):
         translation_object = MagicMock()
 
         with mock.patch(
@@ -185,12 +189,68 @@ class TranslationTest(TestCase):
                 result = get_translation_object(
                     django_language_code="LANGUAGE_CODE",
                     domain="GETTEXT_DOMAIN",
+                    language_default="LANGUAGE_DEFAULT",
                 )
         mock_djt.assert_called_with(
             domain="GETTEXT_DOMAIN",
             language="LANGUAGE_CODE",
+            localedirs="LOCALE_DIRS",
         )
         mock_trans.assert_called_with("LANGUAGE_CODE")
+        self.assertEqual(translation_object, result)
+
+    @override_settings(
+        LANGUAGES_MOSTLY_TRANSLATED=["LANGUAGE_DEFAULT"],
+        LEGAL_CODE_LOCALE_PATH="LOCALE_DIRS",
+    )
+    def test_get_translation_object_default_translated(self):
+        translation_object = MagicMock()
+
+        with mock.patch(
+            "i18n.utils.translation.trans_real.DjangoTranslation"
+        ) as mock_djt:
+            mock_djt.return_value = translation_object
+            with mock.patch(
+                "i18n.utils.translation.trans_real.translation"
+            ) as mock_trans:
+                result = get_translation_object(
+                    django_language_code="LANGUAGE_CODE",
+                    domain="GETTEXT_DOMAIN",
+                    language_default="LANGUAGE_DEFAULT",
+                )
+        mock_djt.assert_called_with(
+            domain="GETTEXT_DOMAIN",
+            language="LANGUAGE_CODE",
+            localedirs="LOCALE_DIRS",
+        )
+        mock_trans.assert_called_with("LANGUAGE_DEFAULT")
+        self.assertEqual(translation_object, result)
+
+    @override_settings(
+        LANGUAGES_MOSTLY_TRANSLATED=[],
+        LEGAL_CODE_LOCALE_PATH="LOCALE_DIRS",
+    )
+    def test_get_translation_object_untranslated(self):
+        translation_object = MagicMock()
+
+        with mock.patch(
+            "i18n.utils.translation.trans_real.DjangoTranslation"
+        ) as mock_djt:
+            mock_djt.return_value = translation_object
+            with mock.patch(
+                "i18n.utils.translation.trans_real.translation"
+            ) as mock_trans:
+                result = get_translation_object(
+                    django_language_code="LANGUAGE_CODE",
+                    domain="GETTEXT_DOMAIN",
+                    language_default="LANGUAGE_DEFAULT",
+                )
+        mock_djt.assert_called_with(
+            domain="GETTEXT_DOMAIN",
+            language="LANGUAGE_CODE",
+            localedirs="LOCALE_DIRS",
+        )
+        mock_trans.assert_called_with(settings.LANGUAGE_CODE)
         self.assertEqual(translation_object, result)
 
     def test_active_translation(self):

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -64,12 +64,8 @@ JURISDICTION_CURRENCY_LOOKUP = {
 }
 
 
-# This function looks like a good candidate for caching, but we might be
-# changing the translated files while running and need to be sure we always
-# read and use the one that's there right now. Anyway, this site doesn't
-# need to perform all that well, since it just generates static files.
 def get_translation_object(
-    *, django_language_code: str, domain: str, language_default: str
+    domain: str, language_code: str, language_default: str
 ) -> translation.trans_real.DjangoTranslation:
     """
     Return a DjangoTranslation object suitable to activate when we're wanting
@@ -78,20 +74,24 @@ def get_translation_object(
 
     This fuction requires the legal code locales path to have been added to
     Django settings.LOCALE_PATHS
+
+    WARNING: this *does* make assumptions about the internals of Django's
+    translation system that could change on us.  It doesn't seem likely,
+    though.
     """
 
     # Start with a translation object for the domain for this tool.
     tool_translation_object = translation.trans_real.DjangoTranslation(
-        language=django_language_code,
+        language=language_code,
         domain=domain,
         localedirs=settings.LEGAL_CODE_LOCALE_PATH,
     )
 
     # Add a fallback to the standard Django translation for this language. This
     # gets us the non-legal-code parts of the pages.
-    if django_language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
         tool_translation_object.add_fallback(
-            translation.trans_real.translation(django_language_code)
+            translation.trans_real.translation(language_code)
         )
     elif language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
         tool_translation_object.add_fallback(
@@ -107,12 +107,13 @@ def get_translation_object(
 
 @contextmanager
 def active_translation(
-    translation_obj: translation.trans_real.DjangoTranslation,
+    translation_object: translation.trans_real.DjangoTranslation,
 ):
     """
     Context manager to do stuff within its context with a particular
     translation object set as the active translation.  (Use
-    ``get_translation_object`` to get a translation object to use with this.)
+    ``legal_code.get_translation_object()`` to get a translation object to use
+    with this.)
 
     Bypasses all the language code stuff that Django does when you use its
     ``activate(language_code)`` function.
@@ -124,19 +125,17 @@ def active_translation(
     translation system that could change on us.  It doesn't seem likely,
     though.
     """
-    _active = translation.trans_real._active
 
-    # Either _active.value points at a DjangoTranslation
-    # object, or _active has no 'value' attribute.
-    previous_translation = getattr(_active, "value", None)
-    _active.value = translation_obj
+    previous_language = translation.trans_real.get_language()
+    translation.trans_real._active.value = translation_object
 
     yield
 
-    if previous_translation is None:
-        translation.deactivate()
-    else:
-        translation.activate(previous_translation.language())
+    # The following logic is based on django.utils.translations.override()
+    if previous_language is not None:
+        translation.activate(previous_language)
+    else:  # pragma: no cover
+        translation.deactivate_all()
 
 
 def save_pofile_as_pofile_and_mofile(pofile: polib.POFile, pofile_path: str):

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -357,9 +357,13 @@ class LegalCode(models.Model):
         return self.tool.resource_slug
 
     def get_translation_object(self):
+        language_default = get_default_language_for_jurisdiction(
+            self.tool.jurisdiction_code
+        )
         return get_translation_object(
             django_language_code=self.language_code,
             domain=self.tool.resource_slug,
+            language_default=language_default,
         )
 
     def get_pofile(self) -> polib.POFile:

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -357,10 +357,9 @@ class LegalCode(models.Model):
         return self.tool.resource_slug
 
     def get_translation_object(self):
-        domain = self.tool.resource_slug
         return get_translation_object(
             django_language_code=self.language_code,
-            domain=domain,
+            domain=self.tool.resource_slug,
         )
 
     def get_pofile(self) -> polib.POFile:

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -361,8 +361,8 @@ class LegalCode(models.Model):
             self.tool.jurisdiction_code
         )
         return get_translation_object(
-            django_language_code=self.language_code,
             domain=self.tool.resource_slug,
+            language_code=self.language_code,
             language_default=language_default,
         )
 

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -258,7 +258,7 @@ class LegalCodeModelTest(TestCase):
         ) as mock_djt:
             legal_code.get_translation_object()
         mock_djt.assert_called_with(
-            django_language_code="de", domain="by-sa_40"
+            django_language_code="de", domain="by-sa_40", language_default="en"
         )
 
     def test_branch_name(self):

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -258,7 +258,7 @@ class LegalCodeModelTest(TestCase):
         ) as mock_djt:
             legal_code.get_translation_object()
         mock_djt.assert_called_with(
-            django_language_code="de", domain="by-sa_40", language_default="en"
+            domain="by-sa_40", language_code="de", language_default="en"
         )
 
     def test_branch_name(self):

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -709,6 +709,7 @@ class ViewLegalCodeTest(TestCase):
             tool__category="licenses",
             tool__base_url="https://creativecommons.org"
             "/licenses/by/3.0/de/",
+            tool__unit="by",
             tool__version="3.0",
             tool__jurisdiction_code="de",
         )
@@ -728,6 +729,7 @@ class ViewLegalCodeTest(TestCase):
         tool = ToolFactory(
             category="licenses",
             base_url="https://creativecommons.org/licenses/by/4.0/",
+            unit="by",
             version="4.0",
         )
         for language_code in ["ar", "es", settings.LANGUAGE_CODE]:
@@ -775,23 +777,21 @@ class ViewLegalCodeTest(TestCase):
         LANGUAGES_MOSTLY_TRANSLATED=["es", settings.LANGUAGE_CODE],
     )
     def test_view_legal_code_30_default_translated(self):
-        tool = ToolFactory(
-            category="licenses",
-            base_url="https://creativecommons.org/licenses/by/3.0/es/",
-            version="3.0",
-        )
         language_code = "ast"
         lc = LegalCodeFactory(
-            tool=tool,
+            tool__category="licenses",
+            tool__base_url="https://creativecommons.org/licenses/by/3.0/es/",
+            tool__unit="by",
+            tool__version="3.0",
+            tool__jurisdiction_code="es",
             language_code=language_code,
+            html="<html></html>",
         )
         url = lc.legal_code_url
         rsp = self.client.get(url)
         self.assertEqual(200, rsp.status_code)
         self.assertTemplateUsed(rsp, "legalcode.html")
-        self.assertTemplateUsed(
-            rsp, "includes/legalcode_licenses_3.0_unported.html"
-        )
+        self.assertTemplateUsed(rsp, "includes/legalcode_crude_html.html")
         context = rsp.context
         self.assertEqual(lc, context["legal_code"])
         self.assertContains(rsp, f'lang="{language_code}"')
@@ -801,23 +801,21 @@ class ViewLegalCodeTest(TestCase):
         LANGUAGES_MOSTLY_TRANSLATED=[settings.LANGUAGE_CODE],
     )
     def test_view_legal_code_30_default_untranslated(self):
-        tool = ToolFactory(
-            category="licenses",
-            base_url="https://creativecommons.org/licenses/by/3.0/es/",
-            version="3.0",
-        )
         language_code = "ast"
         lc = LegalCodeFactory(
-            tool=tool,
+            tool__category="licenses",
+            tool__base_url="https://creativecommons.org/licenses/by/3.0/es/",
+            tool__unit="by",
+            tool__version="3.0",
+            tool__jurisdiction_code="es",
             language_code=language_code,
+            html="<html></html>",
         )
         url = lc.legal_code_url
         rsp = self.client.get(url)
         self.assertEqual(200, rsp.status_code)
         self.assertTemplateUsed(rsp, "legalcode.html")
-        self.assertTemplateUsed(
-            rsp, "includes/legalcode_licenses_3.0_unported.html"
-        )
+        self.assertTemplateUsed(rsp, "includes/legalcode_crude_html.html")
         context = rsp.context
         self.assertEqual(lc, context["legal_code"])
         self.assertContains(rsp, f'lang="{language_code}"')
@@ -857,14 +855,13 @@ class ViewLegalCodeTest(TestCase):
     #     self.assertGreater(len(rsp.content.decode()), 0)
 
     def test_legal_code_translation_by_40_es(self):
-        tool = ToolFactory(
-            category="licenses",
-            base_url="https://creativecommons.org/licenses/by/4.0/",
-            version="4.0",
-        )
+        language_code = "es"
         legal_code = LegalCodeFactory(
-            tool=tool,
-            language_code="es",
+            tool__category="licenses",
+            tool__base_url="https://creativecommons.org/licenses/by/4.0/",
+            tool__unit="by",
+            tool__version="4.0",
+            language_code=language_code,
         )
         url = legal_code.legal_code_url
         rsp = self.client.get(url)

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -741,7 +741,7 @@ class ViewLegalCodeTest(TestCase):
     @override_settings(
         LANGUAGES_MOSTLY_TRANSLATED=["ar", settings.LANGUAGE_CODE],
     )
-    def test_view_legal_code(self):
+    def test_view_legal_code_40(self):
         tool = ToolFactory(
             category="licenses",
             base_url="https://creativecommons.org/licenses/by/4.0/",
@@ -756,9 +756,30 @@ class ViewLegalCodeTest(TestCase):
             rsp = self.client.get(url)
             self.assertEqual(200, rsp.status_code)
             self.assertTemplateUsed(rsp, "legalcode.html")
-            self.assertTemplateUsed(
-                rsp, "includes/legalcode_licenses_4.0.html"
-            )
+            for template in (
+                "base.html",
+                "legalcode.html",
+                "includes/about_cc.html",
+                "includes/about_cc_and_license.html",
+                "includes/footer.html",
+                "includes/header.html",
+                "includes/legalcode_licenses_4.0.html",
+                "includes/legalcode_menu_sidebar.html",
+                "includes/licenses_header.html",
+                "includes/related_links.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/snippet/icon.html",
+                "includes/use_of_licenses.html",
+            ):
+                self.assertTemplateUsed(rsp, template)
             context = rsp.context
             self.assertEqual(lc, context["legal_code"])
             self.assertContains(rsp, f'lang="{language_code}"')
@@ -766,6 +787,58 @@ class ViewLegalCodeTest(TestCase):
                 self.assertContains(rsp, 'dir="ltr"')
             elif language_code == "ar":
                 self.assertContains(rsp, 'dir="rtl"')
+
+    @override_settings(
+        LANGUAGES_MOSTLY_TRANSLATED=["es", settings.LANGUAGE_CODE],
+    )
+    def test_view_legal_code_30_default_translated(self):
+        tool = ToolFactory(
+            category="licenses",
+            base_url="https://creativecommons.org/licenses/by/3.0/es/",
+            version="3.0",
+        )
+        language_code = "ast"
+        lc = LegalCodeFactory(
+            tool=tool,
+            language_code=language_code,
+        )
+        url = lc.legal_code_url
+        rsp = self.client.get(url)
+        self.assertEqual(200, rsp.status_code)
+        self.assertTemplateUsed(rsp, "legalcode.html")
+        self.assertTemplateUsed(
+            rsp, "includes/legalcode_licenses_3.0_unported.html"
+        )
+        context = rsp.context
+        self.assertEqual(lc, context["legal_code"])
+        self.assertContains(rsp, f'lang="{language_code}"')
+        self.assertContains(rsp, 'dir="ltr"')
+
+    @override_settings(
+        LANGUAGES_MOSTLY_TRANSLATED=[settings.LANGUAGE_CODE],
+    )
+    def test_view_legal_code_30_default_untranslated(self):
+        tool = ToolFactory(
+            category="licenses",
+            base_url="https://creativecommons.org/licenses/by/3.0/es/",
+            version="3.0",
+        )
+        language_code = "ast"
+        lc = LegalCodeFactory(
+            tool=tool,
+            language_code=language_code,
+        )
+        url = lc.legal_code_url
+        rsp = self.client.get(url)
+        self.assertEqual(200, rsp.status_code)
+        self.assertTemplateUsed(rsp, "legalcode.html")
+        self.assertTemplateUsed(
+            rsp, "includes/legalcode_licenses_3.0_unported.html"
+        )
+        context = rsp.context
+        self.assertEqual(lc, context["legal_code"])
+        self.assertContains(rsp, f'lang="{language_code}"')
+        self.assertContains(rsp, 'dir="ltr"')
 
     # NOTE: plaintext functionality disabled
     # def test_view_legal_code_plain_text(self):

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -90,23 +90,6 @@ def expected_and_unexpected_strings_for_tool(tool):
     return expected, unexpected
 
 
-# All the valid units. They all start with "by", and have various
-# combinations of "nc", "nd", and "sa", in that order. But not all combinations
-# are valid, e.g. "nd" and "sa" are not compatible.
-units = []
-for bits in range(8):  # We'll enumerate the variations
-    parts = ["by"]
-    if bits & 1:
-        parts.append("nc")
-    if bits & 2:
-        parts.append("nd")
-    if bits & 4:
-        parts.append("sa")
-    if "nd" in parts and "sa" in parts:
-        continue  # Not compatible
-    units.append("-".join(parts))
-
-
 class ToolsTestsMixin:
     # Create some tools to test in setUp
     def setUp(self):

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -497,11 +497,15 @@ def view_legal_code(
     request.path, language_code = normalize_path_and_lang(
         request.path, jurisdiction, language_code
     )
+    language_default = get_default_language_for_jurisdiction(jurisdiction)
     if language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
         translation.activate(language_code)
+    elif language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+        translation.activate(language_default)
+    else:
+        translation.activate(settings.LANGUAGE_CODE)
 
     path_start = os.path.dirname(request.path)
-    language_default = get_default_language_for_jurisdiction(jurisdiction)
 
     # NOTE: plaintext functionality disabled
     # if is_plain_text:
@@ -528,7 +532,6 @@ def view_legal_code(
         tool,
     )
 
-    language_code = legal_code.language_code  # CC language code
     languages_and_links = get_languages_and_links_for_legal_codes(
         path_start=path_start,
         legal_codes=tool.legal_codes.all(),

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -498,12 +498,6 @@ def view_legal_code(
         request.path, jurisdiction, language_code
     )
     language_default = get_default_language_for_jurisdiction(jurisdiction)
-    if language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
-        translation.activate(language_code)
-    elif language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
-        translation.activate(language_default)
-    else:
-        translation.activate(settings.LANGUAGE_CODE)
 
     path_start = os.path.dirname(request.path)
 
@@ -524,44 +518,53 @@ def view_legal_code(
         legal_code_url=request.path,
     )
 
+    # Use Deeds & UX translations for title instead of Legal Code
+    if language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+        translation.activate(language_code)
+    elif language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+        translation.activate(language_default)
+    else:
+        translation.activate(settings.LANGUAGE_CODE)
     tool = legal_code.tool
     tool_title = get_tool_title(tool)
 
-    category, category_title = get_category_and_category_title(
-        category,
-        tool,
-    )
-
-    languages_and_links = get_languages_and_links_for_legal_codes(
-        path_start=path_start,
-        legal_codes=tool.legal_codes.all(),
-        selected_language_code=language_code,
-    )
-
-    deed_rel_path = get_deed_rel_path(
-        legal_code.deed_url,
-        path_start,
-        language_code,
-        language_default,
-    )
-
-    kwargs = dict(
-        template_name="legalcode.html",
-        context={
-            "canonical_url": f"{settings.CANONICAL_SITE}{request.path}",
-            "category": category,
-            "category_title": category_title,
-            "deed_rel_path": deed_rel_path,
-            "identifier": tool.identifier(),
-            "languages_and_links": languages_and_links,
-            "legal_code": legal_code,
-            "tool": tool,
-            "tool_title": tool_title,
-        },
-    )
-
+    # Activate Legal Code translation
     current_translation = legal_code.get_translation_object()
     with active_translation(current_translation):
+
+        category, category_title = get_category_and_category_title(
+            category,
+            tool,
+        )
+
+        languages_and_links = get_languages_and_links_for_legal_codes(
+            path_start=path_start,
+            legal_codes=tool.legal_codes.all(),
+            selected_language_code=language_code,
+        )
+
+        deed_rel_path = get_deed_rel_path(
+            legal_code.deed_url,
+            path_start,
+            language_code,
+            language_default,
+        )
+
+        kwargs = dict(
+            template_name="legalcode.html",
+            context={
+                "canonical_url": f"{settings.CANONICAL_SITE}{request.path}",
+                "category": category,
+                "category_title": category_title,
+                "deed_rel_path": deed_rel_path,
+                "identifier": tool.identifier(),
+                "languages_and_links": languages_and_links,
+                "legal_code": legal_code,
+                "tool": tool,
+                "tool_title": tool_title,
+            },
+        )
+
         # NOTE: plaintext functionality disabled
         # if is_plain_text:
         #     response = HttpResponse(


### PR DESCRIPTION
## Fixes
Fixes #273 
- #273

## Description
App: fix legal code translations
1. Correct coverage tests failing sometimes by correctly setting up test data (legal code translations can not be reliably loaded if the LegalCode's Tool object does not have a unit
2. Correct published legal code with inconsistent Deeds & UX strings by adding logic to language activation:
   1. specified language
   2. fallback to jurisdiction default language
   3. fallback to default language (LANGUAGE_CODE): en English

Also see Data PR: https://github.com/creativecommons/cc-legal-tools-data/pull/92

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1370      0    472      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
