### PR TITLE
App: add disclaimer translations and remove unused translations

### DIFF
--- a/dev/concatenatemessages.sh
+++ b/dev/concatenatemessages.sh
@@ -88,6 +88,7 @@ for _locale_dir in $(find ../cc-legal-tools-data/locale/* -maxdepth 0 -type d); 
     _legacy_locale_2='.INVALID.SHOULD_NOT_EXIST'
     _po_legacy_1=''
     _po_legacy_2=''
+    _po_tmp=''
     case ${_locale} in
         es)
             _legacy_locale_1="${_locale}"
@@ -128,6 +129,11 @@ for _locale_dir in $(find ../cc-legal-tools-data/locale/* -maxdepth 0 -type d); 
         _po_legacy_2="../cc.i18n/cc/i18n/po/${_legacy_locale_2}/cc_org.po"
         echo "    ${_po_legacy_2}"
     fi
+    if [[ -d "tmp/locale/${_locale}" ]]; then
+        _po_tmp="tmp/locale/${_locale}/tmp.po"
+        echo "    ${_po_tmp}"
+    fi
+
 
     msgcat \
         --output-file="${_po_current}" \
@@ -135,7 +141,8 @@ for _locale_dir in $(find ../cc-legal-tools-data/locale/* -maxdepth 0 -type d); 
         --sort-output \
         ${_po_current} \
         ${_po_legacy_1} \
-        ${_po_legacy_2}
+        ${_po_legacy_2} \
+        ${_po_tmp}
 done
 echo
 

--- a/dev/concatenatemessages.sh
+++ b/dev/concatenatemessages.sh
@@ -117,32 +117,39 @@ for _locale_dir in $(find ../cc-legal-tools-data/locale/* -maxdepth 0 -type d); 
            _legacy_locale_1="${_locale}"
            ;;
     esac
+
     if [[ -d "../cc.i18n/cc/i18n/po/${_legacy_locale_1}" ]]; then
         _po_legacy_1="../cc.i18n/cc/i18n/po/${_legacy_locale_1}/cc_org.po"
         echo "    ${_po_legacy_1}"
-    else
-        echo '    *** NOT FOUND ***'
-        echo 'Invalid legacy location. Aborting.' 1>&2
-        exit 1
+        msgcat \
+            --output-file="${_po_current}" \
+            --use-first \
+            --sort-output \
+            ${_po_current} \
+            ${_po_legacy_1}
     fi
+
     if [[ -d "../cc.i18n/cc/i18n/po/${_legacy_locale_2}" ]]; then
         _po_legacy_2="../cc.i18n/cc/i18n/po/${_legacy_locale_2}/cc_org.po"
         echo "    ${_po_legacy_2}"
+        msgcat \
+            --output-file="${_po_current}" \
+            --use-first \
+            --sort-output \
+            ${_po_current} \
+            ${_po_legacy_2}
     fi
-    if [[ -d "tmp/locale/${_locale}" ]]; then
+
+    if [[ -f "tmp/locale/${_locale}/tmp.po" ]]; then
         _po_tmp="tmp/locale/${_locale}/tmp.po"
         echo "    ${_po_tmp}"
+        msgcat \
+            --output-file="${_po_current}" \
+            --use-first \
+            --sort-output \
+            ${_po_current} \
+            ${_po_tmp}
     fi
-
-
-    msgcat \
-        --output-file="${_po_current}" \
-        --use-first \
-        --sort-output \
-        ${_po_current} \
-        ${_po_legacy_1} \
-        ${_po_legacy_2} \
-        ${_po_tmp}
 done
 echo
 

--- a/legal_tools/management/commands/load_html_files.py
+++ b/legal_tools/management/commands/load_html_files.py
@@ -591,6 +591,8 @@ class Command(BaseCommand):
             content = inner_html(soup_obj.p).strip()
             content = content.replace("<i>", "<em>")
             content = content.replace("</i>", "</em>")
+            content = content.replace("“", '"')
+            content = content.replace("”", '"')
             disclaimers.append(content)
 
             # Using Creative Commons Public Licenses
@@ -617,6 +619,10 @@ class Command(BaseCommand):
                     str(soup_obj.contents[2]).strip(),
                 ]
             )
+            content = content.replace('href="//wiki', 'href="https://wiki')
+            content = content.replace(
+                "wiki.creativecommons.org/C", "wiki.creativecommons.org/wiki/C"
+            )
             disclaimers.append(content)
 
             # Considerations for the public
@@ -631,6 +637,10 @@ class Command(BaseCommand):
                     soup_obj.contents[1].string.strip(),
                     str(soup_obj.contents[2]).strip(),
                 ]
+            )
+            content = content.replace('href="//wiki', 'href="https://wiki')
+            content = content.replace(
+                "wiki.creativecommons.org/C", "wiki.creativecommons.org/wiki/C"
             )
             disclaimers.append(content)
 

--- a/legal_tools/management/commands/load_html_files.py
+++ b/legal_tools/management/commands/load_html_files.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser
 from bs4 import BeautifulSoup, Tag
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
+from django.utils.translation import to_locale
 from polib import POEntry, POFile
 
 # First-party/Local
@@ -259,6 +260,7 @@ class Command(BaseCommand):
         )
 
         english_by_unit_version = {}
+        disclaimers_english = []
 
         # We have to do English first. Django gets confused if you try to load
         # another language and it can't find English, I guess it's looking for
@@ -303,7 +305,10 @@ class Command(BaseCommand):
                 if tool.category == "licenses":
                     if version == "4.0":
                         support_po_files = True
-                        messages_text = self.import_by_40_license_html(
+                        (
+                            messages_text,
+                            disclaimers_text,
+                        ) = self.import_by_40_license_html(
                             content=content,
                             legal_code=legal_code,
                         )
@@ -336,6 +341,17 @@ class Command(BaseCommand):
                     )
 
                 if support_po_files and self.pomofiles:
+                    # Deeds & UX temporary
+                    if disclaimers_text:
+                        if language_code == "en":
+                            disclaimers_english = disclaimers_text
+                        self.write_temp_po_files(
+                            language_code,
+                            disclaimers_english,
+                            disclaimers_text,
+                        )
+
+                    # Legal Code
                     if language_code == "en":
                         key = f"{unit}|{version}"
                         english_by_unit_version[key] = messages_text
@@ -345,6 +361,55 @@ class Command(BaseCommand):
                         english_by_unit_version,
                         messages_text,
                     )
+
+    def write_temp_po_files(
+        self,
+        language_code,
+        english,
+        disclaimers_text,
+    ):
+        po_filename = os.path.join(
+            settings.PROJECT_ROOT,
+            "tmp",
+            "locale",
+            to_locale(language_code),
+            "tmp.po",
+        )
+
+        pofile = POFile()
+        # The syntax used to wrap messages in a .po file is
+        # difficult if you ever want to copy/paste the messages, so
+        # if --unwrapped was passed, set a wrap width that will
+        # essentially disable wrapping.
+        if self.unwrapped:
+            pofile.wrapwidth = 999999
+
+        for index, message in enumerate(disclaimers_text):
+            pofile.append(
+                POEntry(
+                    msgid=clean_string(english[index]),
+                    msgstr=clean_string(disclaimers_text[index])
+                    if language_code != "en"
+                    else "",
+                )
+            )
+        # https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html  # noqa: E501
+        pofile.metadata = {
+            "Content-Transfer-Encoding": "8bit",
+            "Content-Type": "text/plain; charset=utf-8",
+            "MIME-Version": "1.0",
+        }
+
+        directory = os.path.dirname(po_filename)
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
+        # Save mofile ourself. We could call 'compilemessages' but
+        # it wants to compile everything, which is both overkill
+        # and can fail if the venv or project source is not
+        # writable. We know this dir is writable, so just save this
+        # pofile and mofile ourselves.
+        LOG.debug(f"Writing {po_filename.replace('.po', '')}.(mo|po)")
+        pofile.save(po_filename)
 
     def write_po_files(
         self,
@@ -516,6 +581,58 @@ class Command(BaseCommand):
         # Get the license titles and intro text.
 
         deed_main_content = soup.find(id="deed-main-content")
+
+        # Extract Legal Code disclaimer translations
+        disclaimers = []
+        if unit == "by":
+            # Creative Commons Corporation (“Creative Commons”) is not a law
+            # firm and does not provide legal services or legal advice...
+            soup_obj = deed_main_content.find("div", class_="shaded")
+            content = inner_html(soup_obj.p).strip()
+            content = content.replace("<i>", "<em>")
+            content = content.replace("</i>", "</em>")
+            disclaimers.append(content)
+
+            # Using Creative Commons Public Licenses
+            soup_obj = soup_obj.find_next_sibling("div").p
+            content = soup_obj.string.strip()
+            disclaimers.append(content)
+
+            # Creative Commons public licenses provide a standard set of terms
+            # and conditions that creators and other rights holders may use...
+            soup_obj = soup_obj.find_next_sibling("p")
+            content = soup_obj.string.strip()
+            disclaimers.append(content)
+
+            # Considerations for licensors
+            soup_obj = soup_obj.find_next_sibling("p")
+            content = soup_obj.strong.string.strip().strip(":")
+            disclaimers.append(content)
+
+            # Our public licenses are intended for use by those authorized to
+            # give the public permission to use material in ways otherwise...
+            content = " ".join(
+                [
+                    soup_obj.contents[1].string.strip(),
+                    str(soup_obj.contents[2]).strip(),
+                ]
+            )
+            disclaimers.append(content)
+
+            # Considerations for the public
+            soup_obj = soup_obj.find_next_sibling("p")
+            content = soup_obj.strong.string.strip().strip(":")
+            disclaimers.append(content)
+
+            # By using one of our public licenses, a licensor grants the
+            # public permission to use the licensed material under...
+            content = " ".join(
+                [
+                    soup_obj.contents[1].string.strip(),
+                    str(soup_obj.contents[2]).strip(),
+                ]
+            )
+            disclaimers.append(content)
 
         messages["license_medium"] = inner_html(
             soup.find(id="deed-license").h2
@@ -868,7 +985,7 @@ class Command(BaseCommand):
 
         validate_dictionary_is_all_text(messages)
 
-        return messages
+        return messages, disclaimers
 
     def import_by_30_unported_license_html(self, *, content, legal_code):
         """


### PR DESCRIPTION
## Description
App: add disclaimer translations and remove unused translations
- Add disclaimer translations
  - Update `load_html_files` management command to extract disclaimer translations from BY 4.0 licenses and write them to a temporary location
  - Update `dev/concatenatemessages.sh` to load translations from the temporary location
- Remove unused translations (English strings removed in #277)

Also see related Data translation PR: https://github.com/creativecommons/cc-legal-tools-data/pull/96

Also see related Data published PR: https://github.com/creativecommons/cc-legal-tools-data/pull/97

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1370      0    472      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
