### PR TITLE
App: add bottom disclaimer translations

### DIFF
--- a/legal_tools/management/commands/load_html_files.py
+++ b/legal_tools/management/commands/load_html_files.py
@@ -81,9 +81,10 @@ class Command(BaseCommand):
         parser.add_argument(
             "--pomofiles",
             action="store_true",
-            help="Write .po and .mo files. This option may cause"
+            help="Write legal code .po and .mo files. This option may cause"
             " discrepencies between the data repository and Transifex and"
-            " should only be used with great care.",
+            " should only be used with great care. (The temporary .po files"
+            " used by locale concatenatemessages.sh are always written.)",
         )
         parser.add_argument(
             "--unwrapped",
@@ -340,7 +341,7 @@ class Command(BaseCommand):
                         f"NotImplementedError: unit={unit} version={version}"
                     )
 
-                if support_po_files and self.pomofiles:
+                if support_po_files:
                     # Deeds & UX temporary
                     if disclaimers_text:
                         if language_code == "en":
@@ -351,6 +352,7 @@ class Command(BaseCommand):
                             disclaimers_text,
                         )
 
+                if support_po_files and self.pomofiles:
                     # Legal Code
                     if language_code == "en":
                         key = f"{unit}|{version}"
@@ -642,6 +644,32 @@ class Command(BaseCommand):
             content = content.replace(
                 "wiki.creativecommons.org/C", "wiki.creativecommons.org/wiki/C"
             )
+            disclaimers.append(content)
+
+            # Creative Commons is not a party to its public licenses.
+            # Notwithstanding, Creative Commons may elect to apply one of...
+            soup_obj = soup.find("p", class_="shaded")
+            paragraphs = inner_html(soup_obj).split("<br/>")
+            content = paragraphs[0].strip()
+            content = content.replace("“", '"')
+            content = content.replace("”", '"')
+            content = content.replace(  # English
+                '"//creativecommons.org/publicdomain/zero/1.0/legalcode"',
+                '"/publicdomain/zero/1.0/"',
+            )
+            content = content.replace(  # Translations
+                '"//creativecommons.org/publicdomain/zero/1.0/',
+                '"/publicdomain/zero/1.0/',
+            )
+            content = content.replace(
+                '"//creativecommons.org/policies"',
+                '"/policies/"',
+            )
+            disclaimers.append(content)
+
+            # Creative Commons may be contacted at <a
+            # href="//creativecommons.org/">creativecommons.org</a>.
+            content = paragraphs[-1].strip()
             disclaimers.append(content)
 
         messages["license_medium"] = inner_html(

--- a/templates/includes/about_cc.html
+++ b/templates/includes/about_cc.html
@@ -16,11 +16,11 @@
       Public Domain Dedication</a>. Except for the limited purpose of
       indicating that material is shared under a Creative Commons public license
       or as otherwise permitted by the Creative Commons policies published at
-      <a href="//creativecommons.org/policies">creativecommons.org/policies</a>,
-      Creative Commons does not authorize the use of the trademark "Creative
-      Commons" or any other trademark or logo of Creative Commons without its
-      prior written consent including, without limitation, in connection with
-      any unauthorized modifications to any of its public licenses or any other
+      <a href="/policies/">creativecommons.org/policies</a>, Creative Commons
+      does not authorize the use of the trademark "Creative Commons" or any
+      other trademark or logo of Creative Commons without its prior written
+      consent including, without limitation, in connection with any
+      unauthorized modifications to any of its public licenses or any other
       arrangements, understandings, or agreements concerning use of licensed
       material. For the avoidance of doubt, this paragraph does not form part
       of the public licenses.

--- a/templates/includes/about_cc.html
+++ b/templates/includes/about_cc.html
@@ -27,7 +27,7 @@
   <p class="has-text-black padding-{% bidi_start %}-big padding-top-normal">
     {% blocktrans trimmed %}
       Creative Commons may be contacted at
-      <a href="//creativecommons.org">creativecommons.org</a>.
+      <a href="//creativecommons.org/">creativecommons.org</a>.
     {% endblocktrans %}
   </p>
 </div>

--- a/templates/includes/about_cc.html
+++ b/templates/includes/about_cc.html
@@ -14,14 +14,16 @@
       "Licensor." The text of the Creative Commons public licenses is dedicated
       to the public domain under the <a href="/publicdomain/zero/1.0/">CC0
       Public Domain Dedication</a>. Except for the limited purpose of
-      indicating that material is shared under a Creative Commons public
-      license or as otherwise permitted by the Creative Commons policies
-      published at <a href="/policies/">creativecommons.org/policies</a>,
-      Creative Commons without its prior written consent including, without
-      limitation, in connection with any unauthorized modifications to any of
-      its public licenses or any other arrangements, understandings, or
-      agreements concerning use of licensed material. For the avoidance of
-      doubt, this paragraph does not form part of the public licenses.
+      indicating that material is shared under a Creative Commons public license
+      or as otherwise permitted by the Creative Commons policies published at
+      <a href="//creativecommons.org/policies">creativecommons.org/policies</a>,
+      Creative Commons does not authorize the use of the trademark "Creative
+      Commons" or any other trademark or logo of Creative Commons without its
+      prior written consent including, without limitation, in connection with
+      any unauthorized modifications to any of its public licenses or any other
+      arrangements, understandings, or agreements concerning use of licensed
+      material. For the avoidance of doubt, this paragraph does not form part
+      of the public licenses.
     {% endblocktrans %}
   </p>
   <p class="has-text-black padding-{% bidi_start %}-big padding-top-normal">


### PR DESCRIPTION
## Description
App: add bottom disclaimer translations
  - Update `load_html_files` management command to extract bottom disclaimer translations from BY 4.0 licenses and write them to a temporary location
  - Clean-up text
  - Correct template to match text

Also see related Data translation PR: https://github.com/creativecommons/cc-legal-tools-data/pull/98

Also see related Data published PR: https://github.com/creativecommons/cc-legal-tools-data/pull/99

## Tests
```
Name    Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------
------------------------------------------------------
TOTAL    1370      0    472      0   100.00%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
