### PR TITLE
fix #docker-compose-setup anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Esoteric and dangerous:
 The coverage tests and report are run as part of pre-commit and as a GitHub
 Action. To run it manually:
 1. Ensure the [Data Repository](#data-repository), above, is in place
-2. Ensure [Docker Compose Setup](#docker compose-setup), above, is complete
+2. Ensure [Docker Compose Setup](#docker-compose-setup), above, is complete
 2. Coverage test
     ```
     docker compose exec app coverage run manage.py test --noinput --keepdb
@@ -373,7 +373,7 @@ This process will read the HTML files from the specified directory, populate
 [creativecommons/cc-legal-tools-data][repodata].
 
 1. Ensure the [Data Repository](#data-repository), above, is in place
-2. Ensure [Docker Compose Setup](#docker compose-setup), above, is complete
+2. Ensure [Docker Compose Setup](#docker-compose-setup), above, is complete
 3. Clear data in the database
     ```
     docker compose exec app ./manage.py clear_license_data
@@ -496,7 +496,7 @@ This Django Admin command must be run any time the `.po` files are created or
 changed.
 
 1. Ensure the [Data Repository](#data-repository), above, is in place
-2. Ensure [Docker Compose Setup](#docker compose-setup), above, is complete
+2. Ensure [Docker Compose Setup](#docker-compose-setup), above, is complete
 3. Compile translation messages (update `.mo` files)
     ```
     docker compose exec app ./manage.py compilemessages
@@ -517,7 +517,7 @@ directory under `docs/`. It will not commit the changes (`--nogit`) and will
 not push any commits (`--nopush` is implied by `--nogit`).
 
 1. Ensure the [Data Repository](#data-repository), above, is in place
-2. Ensure [Docker Compose Setup](#docker compose-setup), above, is complete
+2. Ensure [Docker Compose Setup](#docker-compose-setup), above, is complete
 3. Compile translation messages (update `.mo` files)
     ```
     docker compose exec app ./manage.py publish --nogit --branch=main


### PR DESCRIPTION
## Description
- fix `#docker-compose-setup` anchors
  - simple fix of a problem I introduced with a previous search & replace:
    - #257 

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
