### PR TITLE
[#341] [Fix] Run development server on correct IP address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   app:
     build: .
-    command: ./manage.py runserver 0.0.0.0:${PORT_APP}
+    command: ./manage.py runserver 127.0.0.1:${PORT_APP}
     environment:
       - DJANGO_SETTINGS_MODULE=${DOCKER_DJANGO_SETTINGS_MODULE}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
 
   app:
     build: .
-    command: ./manage.py runserver 127.0.0.1:${PORT_APP}
+    command: ./manage.py runserver 0.0.0.0:${PORT_APP}
     environment:
       - DJANGO_SETTINGS_MODULE=${DOCKER_DJANGO_SETTINGS_MODULE}
     ports:
-      - "${PORT_APP}:${PORT_APP}"
+      - "127.0.0.1:${PORT_APP}:${PORT_APP}"
     restart: always
     volumes:
       - .:/home/cc/cc-legal-tools-app


### PR DESCRIPTION
## Fixes
Fixes #341  by @0saurabh0

## Description
Before the change, the development server ran on `0.0.0.0:8005` instead of `127.0.0.1:8005`, as listed by the `README.md`. After a simple configuration change for `docker-compose.yml`, the problem seems to be fixed. (As visible from the screenshot.)

## Tests
Since the fix was a simple change in the configuration file, the black/isort tests for Python are not necessary. Please note that I've still run all pre-commit hooks beforehand.

## Screenshots

<img width="917" alt="image" src="https://user-images.githubusercontent.com/28886624/226880371-d3233fbf-8749-4a21-b09b-0295e9f1aff9.png">

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
