### PR TITLE
set RDF.type and pretty print xml for syntactic compression

### DIFF
--- a/legal_tools/rdf_generator.py
+++ b/legal_tools/rdf_generator.py
@@ -31,7 +31,7 @@ def generate_rdf_triples(unit, version, jurisdiction=None):
     # license URI
     license_uri = URIRef(license_data.base_url)
 
-    g.set((license_uri, RDF.type, CC.license))
+    g.set((license_uri, RDF.type, CC.License))
     g.add((license_uri, DC.identifier, Literal(f"{unit}")))
     g.add((license_uri, DCTERMS.hasVersion, Literal(f"{version}")))
     g.add((license_uri, DC.creator, URIRef(license_data.creator_url)))

--- a/legal_tools/rdf_generator.py
+++ b/legal_tools/rdf_generator.py
@@ -31,6 +31,7 @@ def generate_rdf_triples(unit, version, jurisdiction=None):
     # license URI
     license_uri = URIRef(license_data.base_url)
 
+    g.set((license_uri, RDF.type, CC.license))
     g.add((license_uri, DC.identifier, Literal(f"{unit}")))
     g.add((license_uri, DCTERMS.hasVersion, Literal(f"{version}")))
     g.add((license_uri, DC.creator, URIRef(license_data.creator_url)))

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -770,11 +770,10 @@ def render_redirect(title, destination, language_code):
 
 def view_generate_rdf(request, unit, version, jurisdiction=None):
     rdf_content = generate_rdf_triples(unit, version, jurisdiction)
-    serialized_rdf_content = rdf_content.serialize(format="xml").strip("utf-8")
+    serialized_rdf_content = rdf_content.serialize(format="pretty-xml").strip(
+        "utf-8"
+    )
 
-    serialized_rdf_content = serialized_rdf_content.replace(
-        "<rdf:Description", "<cc:License", 1
-    ).replace("</rdf:Description>", "</cc:License>", 1)
     response = HttpResponse(
         serialized_rdf_content, content_type="application/rdf+xml"
     )


### PR DESCRIPTION
## Description
- Set RDF.type and pretty print xml for syntactic compression
  - Removing the `.replace()` will make future efforts (like sorting) easier
  - Based on [Answer 32203700 - python - How to change `rdf:description` namespace using rdflib? - Stack Overflow](https://stackoverflow.com/a/32203700)

👉🏻 @0saurabh0 please merge (into your `rdf_gen` branch), if you do not have any concerns

## Technical details
- [Adding Triples to a graph — Creating RDF triples — rdflib 6.3.2 documentation](https://rdflib.readthedocs.io/en/stable/intro_to_creating_rdf.html#adding-triples-to-a-graph)
  > For some properties, only one value per resource makes sense (i.e they are _functional properties_, or have a max-cardinality of 1). The [`set()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html#rdflib.graph.Graph.set) method is useful for this

### Output
For CC BY 3.0, it results in only whitespace changes:
```diff
--- by3.old.rdf	2023-07-17 09:38:10
+++ by3.new.rdf	2023-07-17 09:39:16
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rdf:RDF
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dcq="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:cc="http://creativecommons.org/ns#"
+  xmlns:dcq="http://purl.org/dc/terms/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 >
   <cc:License rdf:about="https://creativecommons.org/licenses/by/3.0/">
     <dc:identifier>by</dc:identifier>
```

(For CC BY 4.0, there are also no functional changes, but the diff is noisy due to the output not yet being deterministic)


## Tests
Not yet completed. Coverage fails (acceptable on dev branches).


<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
