### PR TITLE
add support for deterministic RDF/XML generation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ dealer = "*"
 Django = ">=3.2.19,<3.3"
 colorlog = "*"
 GitPython = "*"
-lxml = "*"  # For use by beautifulsoup4 (but not a stated dependency)
+lxml = "*"  # Used for RDF/XML processing and by beautifulsoup4
 polib = "*"
 python-dateutil = "*"
 PyYAML = "*"

--- a/legal_tools/rdf_generator.py
+++ b/legal_tools/rdf_generator.py
@@ -86,7 +86,6 @@ def generate_rdf_triples(unit, version, jurisdiction=None):
             )
         )
         # added DCTERMS.language for every legal_code_url
-        # currently the output is not sorted as it should be; but it is expected soon.
         g.add((CC[legal_code_url], DCTERMS.language, Literal(tool_lang)))
 
     # Adding properties


### PR DESCRIPTION
## Description
add (ugly) support for deterministic RDF/XML generation

It's an ugly solution 🙈 Maybe, in the future, we can instead write an Ordered XML Serializer for rdflib, like was done for Turtle ([scriptotek/otsrdflib](https://github.com/scriptotek/otsrdflib): *Ordered Turtle Serializer for rdflib*).

👉🏻 @0saurabh0 please merge, if you do not have any concerns

## Technical details
### Constraints
1. `rdflib` does not support deterministic output at all
2. `lxml` elements can be ordered, but it does not support deterministic output of the namespace
3. `xml.etree.ElementTree` automatically orders the namespce, but does not support mapping prefixes (this means that the elements can be sorted, but they might appear unsorted in the output)

### References
- [rdflib 6.3.2 — rdflib 6.3.2 documentation](https://rdflib.readthedocs.io/en/stable/index.html#)
- [lxml - Processing XML and HTML with Python](https://lxml.de/index.html)
  - [Namespaces - The lxml.etree Tutorial](https://lxml.de/tutorial.html#namespaces)
    > Therefore, modifying the returned [namespace] dict cannot have any meaningful impact on the Element. Any changes to it are ignored.
- [xml.etree.ElementTree — The ElementTree XML API — Python 3.9.17 documentation](https://docs.python.org/3.9/library/xml.etree.elementtree.html)

## Tests
Not yet completed. Coverage fails (acceptable on dev branches).

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
