### PR TITLE
App: Add temporary attention section to 4.0 by-nc-nd and by-nd

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,12 @@
 
 {% include 'includes/header.html' %}
 
+{% block attention %}{% comment %}{#
+<article class="attention">
+<p></p>
+</article>
+#}{% endcomment %}{% endblock %}
+
 <span id="main-content-marker"></span>
 <main>
 

--- a/templates/legalcode.html
+++ b/templates/legalcode.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load bidi i18n static %}
+{% load i18n license_tags static %}
 
 
 {% block title %}
@@ -9,6 +9,25 @@
 
 {% block head_extra %}
 <link href="/cc-legal-tools/legalcode.css" rel="stylesheet"/>
+{% endblock %}
+
+
+{# temporary attention for issues: #365, #366, and #367 #}
+{% block attention %}
+{% if tool.category == "licenses" and tool.version == "4.0" and legal_code|is_one_of:"by-nc-nd,by-nd" %}
+<article class="attention">
+<p>
+We have identified an error in the legal code below. It was caused by our
+recent site relaunch and will be corrected soon. Until then, please reference
+the English plain text version:
+{% if legal_code|is_one_of:"by-nc-nd" %}
+<a href="/licenses/by-nc-nd/4.0/legalcode.txt">/licenses/by-nc-nd/4.0/legalcode.txt</a>
+{% else %}
+<a href="/licenses/by-nd/4.0/legalcode.txt">/licenses/by-nd/4.0/legalcode.txt</a>
+{% endif %}
+</p>
+</article>
+{% endif %}
 {% endblock %}
 
 


### PR DESCRIPTION
## Description
App: Add temporary attention section to 4.0 by-nc-nd and by-nd until errors are resolved

Also see related Data PR: creativecommons/cc-legal-tools-data#144

## Technical details
Related issues:
- #365
- #366,
- #367

## Tests
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1641      0    562      0  100.00%

20 files skipped due to complete coverage.
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
