### PR TITLE
App: correct language redirects

### DIFF
--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -451,13 +451,12 @@ class Command(BaseCommand):
         widths = [max(map(len, map(str, col))) for col in zip(*redirect_pairs)]
         redirect_lines = []
         for pair in redirect_pairs:
-            pcre_match = f'"{pair[0]}"'
+            pcre_match = f'"^{pair[0]}$"'
             pad = widths[0] + 2
             redirect_lines.append(
                 f'RedirectMatch  301  {pcre_match.ljust(pad)}  "{pair[1]}"'
             )
         del redirect_pairs
-        redirect_lines.sort(reverse=True)
         redirect_lines.sort(reverse=True)
         include_lines = [
             "# DO NOT EDIT MANUALLY",
@@ -474,7 +473,7 @@ class Command(BaseCommand):
             "# Step 1: Redirect mixed/uppercase to lowercase",
             "#",
             "# Must be set within virtual host context:",
-            "#     RewriteMap lowercase int:tolower",
+            "RewriteMap lowercase int:tolower",
             "RewriteCond $1 [A-Z]",
             "RewriteRule ^/?(.*)$ /${lowercase:$1} [R=301,L]",
             "",


### PR DESCRIPTION
## Description
App: correct language redirects

Also see related Data PR:
- creativecommons/cc-legal-tools-data#145

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1641      0    562      0  100.00%

20 files skipped due to complete coverage.
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
