### PR TITLE
App: add en-gb redirect

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -223,7 +223,7 @@ LANGMAP_DJANGO_TO_PCRE = {
     # The following PCREs handle altnate codes and characters. Alternate case
     # should be handled by an Apache RewriteMap.
     "de-at": ["de[@_]at"],
-    "en": ["en[@_-]us", "en[@_-]gb"],
+    "en": ["en[@_-]gb", "en[@_-]us"],
     "en-ca": ["en[@_]ca"],
     "en-gb": ["en[@_]gb"],
     "es": ["es[@_-]es"],

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -223,7 +223,7 @@ LANGMAP_DJANGO_TO_PCRE = {
     # The following PCREs handle altnate codes and characters. Alternate case
     # should be handled by an Apache RewriteMap.
     "de-at": ["de[@_]at"],
-    "en": ["en[@_-]us"],
+    "en": ["en[@_-]us", "en[@_-]gb"],
     "en-ca": ["en[@_]ca"],
     "en-gb": ["en[@_]gb"],
     "es": ["es[@_-]es"],

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -492,6 +492,10 @@ class LegalCodeModelTest(TestCase):
         self.assertEqual(
             [
                 [
+                    "/license/by/4[.]0/legalcode[.]en[@_-]gb(?:[.]html)?",
+                    "/license/by/4.0/legalcode.en",
+                ],
+                [
                     "/license/by/4[.]0/legalcode[.]en[@_-]us(?:[.]html)?",
                     "/license/by/4.0/legalcode.en",
                 ],


### PR DESCRIPTION
## Fixes
Fixes #385 
- #385 

## Description
App: add en-gb redirect

Also see Data PR:
- creativecommons/cc-legal-tools-data#158

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1641      0    562      0  100.00%

20 files skipped due to complete coverage.
```

Testing using [creativecommons/index-dev-env](https://github.com/creativecommons/index-dev-env):
Old:
```
http -h http://localhost:8080/licenses/by-sa/2.0/deed.en-gb
```
```
HTTP/1.1 404 Not Found
Connection: Keep-Alive
Content-Length: 273
Content-Type: text/html; charset=iso-8859-1
Date: Tue, 07 Nov 2023 17:49:30 GMT
Keep-Alive: timeout=5, max=100
Server: Apache/2.4.56 (Debian)
```

New:
```
http -h http://localhost:8080/licenses/by-sa/2.0/deed.en-gb
```
```
HTTP/1.1 301 Moved Permanently
Connection: Keep-Alive
Content-Length: 333
Content-Type: text/html; charset=iso-8859-1
Date: Tue, 07 Nov 2023 17:48:08 GMT
Keep-Alive: timeout=5, max=100
Location: http://localhost:8080/licenses/by-sa/2.0/deed.en
Server: Apache/2.4.56 (Debian)
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
