### PR TITLE
App: Add RedirectMatch for ccEngine bug URLs including bare directory

### DIFF
--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -455,8 +455,7 @@ class Command(BaseCommand):
             # deed
             redirect_pairs.append(
                 [
-                    f"/licenses/{unit}/4[.]0/([^/]+)/"
-                    "(deed|deed[.]html)?",
+                    f"/licenses/{unit}/4[.]0/([^/]+)/(deed|deed[.]html)?",
                     f"/licenses/{unit}/4.0/deed.$1",
                 ]
             )

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -448,17 +448,26 @@ class Command(BaseCommand):
         for pair_list in redirect_pairs_data:
             redirect_pairs += pair_list
         del redirect_pairs_data
-        # Add RedirectMatch for ccEngine bug URLs. An entry is added for each
-        # of the 4.0 licenses (versus a single regex) to increase readability.
+        # Add RedirectMatch for ccEngine bug URLs. Entries are added for each
+        # of the 4.0 licenses (versus only two regex) to increase readability.
         # https://github.com/creativecommons/cc-legal-tools-app/issues/438
         for unit in ("by", "by-nc", "by-nc-nd", "by-nc-sa", "by-nd", "by-sa"):
+            # deed
             redirect_pairs.append(
                 [
                     f"/licenses/{unit}/4[.]0/([^/]+)/"
-                    "(deed|legalcode)(?:[.]html)?",
-                    f"/licenses/{unit}/4.0/$2.$1",
+                    "(deed|deed[.]html)?",
+                    f"/licenses/{unit}/4.0/deed.$1",
                 ]
             )
+            # legalcode
+            redirect_pairs.append(
+                [
+                    f"/licenses/{unit}/4[.]0/([^/]+)/legalcode(?:[.]html)?",
+                    f"/licenses/{unit}/4.0/legalcode.$1",
+                ]
+            )
+
         widths = [max(map(len, map(str, col))) for col in zip(*redirect_pairs)]
         pad = widths[0] + 2
         redirect_lines = []


### PR DESCRIPTION
## Fixes
- Fixes #438

## Description
App: Add RedirectMatch for ccEngine bug URLs including bare directory

Also see related Data PR:
 - creativecommons/cc-legal-tools-data#192

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
command:
```shell
./dev/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1682      0    636      0  100.00%

20 files skipped due to complete coverage.
```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
