### PR TITLE
App: Fix missing canonical URLs

### DIFF
--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -13,7 +13,8 @@ from django.test import TestCase, override_settings
 # First-party/Local
 from i18n.utils import (
     active_translation,
-    get_default_language_for_jurisdiction,
+    get_default_language_for_jurisdiction_deed,
+    get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
     get_pofile_creation_date,
     get_pofile_path,
@@ -160,14 +161,32 @@ class UtilTest(TestCase):
 
 
 class I18NTest(TestCase):
-    def test_get_language_for_jurisdiction(self):
-        # 'be' default is "fr"
+    def test_get_language_for_jurisdiction_deed(self):
+        # "be" jurisdiction default is "fr"
         self.assertEqual(
-            "fr", get_default_language_for_jurisdiction("be", "ar")
+            "fr", get_default_language_for_jurisdiction_deed("be")
         )
-        # There is none for "xx" so we return the default instead
+        # "am" jurisdiction default is "hy"
+        # the "hy" translation is incomplete so we return the global default
+        # https://github.com/creativecommons/cc-legal-tools-app/issues/444
         self.assertEqual(
-            "ar", get_default_language_for_jurisdiction("xx", "ar")
+            "en", get_default_language_for_jurisdiction_deed("am")
+        )
+        # "xx" is an invalid jurisdiction
+        # return global default ("en")
+        self.assertEqual(
+            "en", get_default_language_for_jurisdiction_deed("xx")
+        )
+
+    def test_get_language_for_jurisdiction_legal_code(self):
+        # "be" jurisdiction default is "fr"
+        self.assertEqual(
+            "fr", get_default_language_for_jurisdiction_naive("be")
+        )
+        # "xx" is an invalid jurisdiction
+        # return global default ("en")
+        self.assertEqual(
+            "en", get_default_language_for_jurisdiction_naive("xx")
         )
 
 

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -253,13 +253,19 @@ def map_legacy_to_django_language_code(legacy_language_code: str) -> str:
     return django_language_code
 
 
-def get_default_language_for_jurisdiction(
-    jurisdiction_code, default_language=settings.LANGUAGE_CODE
-):
-    # Input: a jurisdiction code
-    # Output: a CC language code
+def get_default_language_for_jurisdiction_deed(jurisdiction_code):
+    default_language = DEFAULT_JURISDICTION_LANGUAGES.get(
+        jurisdiction_code, settings.LANGUAGE_CODE
+    )
+    if default_language in settings.LANGUAGES_MOSTLY_TRANSLATED:
+        return default_language
+    else:
+        return settings.LANGUAGE_CODE
+
+
+def get_default_language_for_jurisdiction_naive(jurisdiction_code):
     return DEFAULT_JURISDICTION_LANGUAGES.get(
-        jurisdiction_code, default_language
+        jurisdiction_code, settings.LANGUAGE_CODE
     )
 
 

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -12,7 +12,8 @@ from django.utils import translation
 # First-party/Local
 from i18n import LANGMAP_DJANGO_TO_PCRE
 from i18n.utils import (
-    get_default_language_for_jurisdiction,
+    get_default_language_for_jurisdiction_deed,
+    get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
     get_pofile_path,
     get_translation_object,
@@ -248,7 +249,9 @@ class LegalCode(models.Model):
         language_code = self.language_code
         tool = self.tool
         juris_code = tool.jurisdiction_code
-        language_default = get_default_language_for_jurisdiction(juris_code)
+        language_default = get_default_language_for_jurisdiction_naive(
+            juris_code
+        )
         filename = f"legalcode.{self.language_code}.html"
 
         # Relative path
@@ -345,7 +348,7 @@ class LegalCode(models.Model):
         return self.tool.resource_slug
 
     def get_translation_object(self):
-        language_default = get_default_language_for_jurisdiction(
+        language_default = get_default_language_for_jurisdiction_naive(
             self.tool.jurisdiction_code
         )
         return get_translation_object(
@@ -551,7 +554,7 @@ class Tool(models.Model):
         """
         Return a dictionary with the metadata for this tool.
         """
-        language_default = get_default_language_for_jurisdiction(
+        language_default = get_default_language_for_jurisdiction_deed(
             self.jurisdiction_code
         )
         data = {}
@@ -598,7 +601,9 @@ class Tool(models.Model):
            correctly
         """
         juris_code = self.jurisdiction_code
-        language_default = get_default_language_for_jurisdiction(juris_code)
+        language_default = get_default_language_for_jurisdiction_deed(
+            juris_code
+        )
         filename = f"deed.{language_code}.html"
 
         # Relative path

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -290,8 +290,9 @@ class LegalCodeModelTest(TestCase):
         self.assertTrue(lc_fr.has_english())
         self.assertTrue(lc_en.has_english())
 
-    # get_publish_files BY-NC-ND 4.0 #########################################
-    # BY-NC-ND 4.0 is an international license with multiple languages
+    # get_publish_files BY-NC-ND 4.0 legal code ##############################
+    # BY-NC-ND 4.0 is an international (unported) license with multiple
+    # languages
 
     def test_get_publish_files_by_nc_nd4_legal_code_en(self):
         legal_code = LegalCodeFactory(
@@ -337,7 +338,7 @@ class LegalCodeModelTest(TestCase):
             returned_list,
         )
 
-    # get_publish_files BY-NC 3.0 CA #########################################
+    # get_publish_files BY-NC 3.0 CA legal code ##############################
     # BY-NC 3.0 CA is a ported license with multiple languages
 
     def test_get_publish_files_by_nc3_legal_code_ca_en(self):
@@ -363,7 +364,7 @@ class LegalCodeModelTest(TestCase):
             returned_list,
         )
 
-    # get_publish_files BY-SA 3.0 AM #########################################
+    # get_publish_files BY-SA 3.0 AM legal code ##############################
     # BY-SA 3.0 AM is a ported license with a single language
 
     def test_get_publish_files_by_sa3_legal_code_am_hy(self):
@@ -389,8 +390,8 @@ class LegalCodeModelTest(TestCase):
             returned_list,
         )
 
-    # LegalCode.get_publish_files CC0 1.0 ####################################
-    # CC0 1.0 is an unported dedication with multiple languages
+    # get_publish_files CC0 1.0 legal code ###################################
+    # CC0 1.0 is a univeral (unported) dedication with multiple languages
 
     def test_get_publish_files_zero_legal_code_en(self):
         legal_code = LegalCodeFactory(
@@ -436,8 +437,8 @@ class LegalCodeModelTest(TestCase):
             returned_list,
         )
 
-    # get_publish_files Mark 1.0 #############################################
-    # Mark 1.0 is an unported deed-only declaration
+    # get_publish_files Mark 1.0 legal code ##################################
+    # Mark 1.0 is a universal (unported) deed-only declaration
 
     def test_get_publish_files_mark_legal_code_en(self):
         legal_code = LegalCodeFactory(
@@ -732,8 +733,9 @@ class ToolModelTest(TestCase):
         for key in expected_data.keys():
             self.assertEqual(expected_data[key], data[key])
 
-    # get_publish_files BY-NC-ND 4.0 #########################################
-    # BY-NC-ND 4.0 is an international license with multiple languages
+    # get_publish_files BY-NC-ND 4.0 deed ####################################
+    # BY-NC-ND 4.0 is an international (unported) license with multiple
+    # languages
 
     def test_get_publish_files_by_nc_nd4_deed_en(self):
         language_code = "en"
@@ -755,7 +757,7 @@ class ToolModelTest(TestCase):
             returned_list,
         )
 
-    # get_publish_files BY-NC 3.0 CA #########################################
+    # get_publish_files BY-NC 3.0 CA deed ####################################
     # BY-NC 3.0 CA is a ported license with multiple languages
 
     def test_get_publish_files_by_nc3_deed_ca_en(self):
@@ -779,8 +781,9 @@ class ToolModelTest(TestCase):
             returned_list,
         )
 
-    # get_publish_files BY-NC-ND 4.0 #########################################
-    # BY-NC-ND 4.0 is an international license with multiple languages
+    # get_publish_files BY-NC-ND 4.0 deed ####################################
+    # BY-NC-ND 4.0 is an international (unported) license with multiple
+    # languages
 
     def test_get_publish_files_by_nc_nd_4_deed_zh_hant(self):
         # English content is returned as translation.activate() is not used
@@ -803,8 +806,33 @@ class ToolModelTest(TestCase):
             returned_list,
         )
 
-    # get_publish_files BY-SA 3.0 AM #########################################
+    # get_publish_files BY-SA 3.0 AM deed ####################################
     # BY-SA 3.0 AM is a ported license with a single language
+
+    def test_get_publish_files_by_sa3_deed_am_en(self):
+        # English content is returned as translation.activate() is not used
+        language_code = "en"
+        tool = ToolFactory(
+            category="licenses",
+            jurisdiction_code="am",
+            unit="by-sa",
+            version="3.0",
+        )
+
+        returned_list = tool.get_publish_files(language_code)
+
+        # symlinks should be populated as the Armenian Deeds & UX translation
+        # is incomplete
+        # https://github.com/creativecommons/cc-legal-tools-app/issues/444
+        self.assertEqual(
+            [
+                # relpath
+                "licenses/by-sa/3.0/am/deed.en.html",
+                # symlinks
+                ["deed.html", "index.html"],
+            ],
+            returned_list,
+        )
 
     def test_get_publish_files_by_sa3_deed_am_hy(self):
         # English content is returned as translation.activate() is not used
@@ -818,18 +846,21 @@ class ToolModelTest(TestCase):
 
         returned_list = tool.get_publish_files(language_code)
 
+        # symlinks shouldn't be populated as the Armenian Deeds & UX
+        # translation is incomplete
+        # https://github.com/creativecommons/cc-legal-tools-app/issues/444
         self.assertEqual(
             [
                 # relpath
                 "licenses/by-sa/3.0/am/deed.hy.html",
                 # symlinks
-                ["deed.html", "index.html"],
+                [],
             ],
             returned_list,
         )
 
-    # get_publish_files CC0 1.0 ##############################################
-    # CC0 1.0 is an unported dedication with multiple languages
+    # get_publish_files CC0 1.0 deed #########################################
+    # CC0 1.0 is a universal (unported) dedication with multiple languages
 
     def test_get_publish_files_zero_deed_en(self):
         language_code = "en"

--- a/legal_tools/tests/test_utils.py
+++ b/legal_tools/tests/test_utils.py
@@ -309,8 +309,6 @@ class ParseLegalcodeFilenameTest(TestCase):
                 self.assertEqual(expected_result, result)
         with self.assertRaisesMessage(ValueError, "Invalid language_code="):
             utils.parse_legal_code_filename("by_3.0_es_aaa")
-        with self.assertRaisesMessage(ValueError, "What language? "):
-            utils.parse_legal_code_filename("by_3.0_zz")
 
 
 class GetToolUtilityTest(TestCase):

--- a/legal_tools/utils.py
+++ b/legal_tools/utils.py
@@ -11,7 +11,7 @@ from django.urls import get_resolver
 # First-party/Local
 import legal_tools.models
 from i18n.utils import (
-    get_default_language_for_jurisdiction,
+    get_default_language_for_jurisdiction_naive,
     map_legacy_to_django_language_code,
 )
 from legal_tools.views import render_redirect
@@ -143,17 +143,17 @@ def parse_legal_code_filename(filename):
     if parts:
         language_code = map_legacy_to_django_language_code(parts.pop(0))
     if jurisdiction:
-        language_code = language_code or get_default_language_for_jurisdiction(
-            jurisdiction, ""
+        language_code = (
+            language_code
+            or get_default_language_for_jurisdiction_naive(jurisdiction)
         )
     else:
         language_code = language_code or settings.LANGUAGE_CODE
-    if not language_code:
-        raise ValueError(f"What language? filename={filename}")
+
+    # Valid Django language_codes are extended in settings with the
+    # defaults in:
+    # https://github.com/django/django/blob/main/django/conf/global_settings.py
     if language_code not in settings.LANG_INFO:
-        # Valid Django language_codes are extended in settings with the
-        # defaults in:
-        # https://github.com/django/django/blob/main/django/conf/global_settings.py
         raise ValueError(f"{filename}: Invalid language_code={language_code}")
 
     base_url = compute_base_url(category, unit, version, jurisdiction)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #444 by @dhruvkb

## Description
App: Fix missing canonical URLs
- improve default language logic
  - rename ~~`get_default_language_for_jurisdiction`~~ to `get_default_language_for_jurisdiction_naive`
    - primarily used for legal code
  - add `get_default_language_for_jurisdiction_deed`
    - consults `settings.LANGUAGES_MOSTLY_TRANSLATED`
- coincidentally improves `hreflang="x-default"` behavior for ported deeds
  - see also: #268 

Also see related Data PR:
- creativecommons/cc-legal-tools-data#193

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
command
```shell
./dev/coverage
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1690      0    638      0  100.00%

20 files skipped due to complete coverage.
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
