### PR TITLE
Add About section to README and stats script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 # between them and this file:
 # - https://github.com/github/gitignore/blob/master/Python.gitignore
 
+# OS generated files
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+
 # Byte-compiled / optimized / DLL files
 *$py.class
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -30,11 +30,28 @@ See [`CONTRIBUTING.md`][org-contrib].
 [org-contrib]: https://github.com/creativecommons/.github/blob/main/CONTRIBUTING.md
 
 
-## Not the live site
+## About
+
+This application manages 639 legal tools (636 licenses and 3 public domain
+tools). The current version of the licenses is 4.0 and includes 6 licenses.
+They are international and are designed to operate globally, ensuring they are
+robust, enforceable and easily adopted worldwide. Prior versions were adapted
+to specific jurisdictions ("ported"). That is why there are 636 licenses.
+
+Broadly speaking, each legal tool consists of three layers:
+1. `deed`: a plain language summary of the legal tool
+2. `legalcode`: the legal tool itself
+3. `rdf`: metadata about the legal tool in RDF/XML format
+
+With translations of the deed and translations of the legal code, this
+application manages over 30,000 documents.
+
+
+### Not the live site
 
 This project is not intended to serve the legal tools directly. Instead, a
 command line tool can be used to save all the rendered HTML and RDF/XML pages
-as files.  Then those files are used as part of the real CreativeCommons.org
+as files. Then those files are used as part of the CreativeCommons.org
 site (served as static files).
 
 

--- a/dev/stats.sh
+++ b/dev/stats.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -o errexit
+set -o errtrace
+set -o nounset
+
+# shellcheck disable=SC2154
+trap '_es=${?};
+    printf "${0}: line ${LINENO}: \"${BASH_COMMAND}\"";
+    printf " exited with a status of ${_es}\n";
+    exit ${_es}' ERR
+
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+E0="$(printf "\e[0m")"        # reset
+E1="$(printf "\e[1m")"        # bold
+E4="$(printf "\e[4m")"        # underline
+E30="$(printf "\e[30m")"      # black foreground
+E31="$(printf "\e[31m")"      # red foreground
+E33="$(printf "\e[33m")"      # yellow foreground
+E97="$(printf "\e[97m")"      # bright white foreground
+E100="$(printf "\e[100m")"    # bright black (gray) background
+E107="$(printf "\e[107m")"    # bright white background
+DIR_REPO="$(cd -P -- "${0%/*}/.." && pwd -P)"
+DIR_PUB_LICENSES="$(cd -P -- \
+    "${DIR_REPO}/../cc-legal-tools-data/docs/licenses" && pwd -P)"
+DIR_PUB_PUBLICDOMAIN="$(cd -P -- \
+    "${DIR_REPO}/../cc-legal-tools-data/docs/publicdomain" && pwd -P)"
+
+
+#### FUNCTIONS ################################################################
+
+
+check_prerequisites() {
+    if ! command -v scc &>/dev/null
+    then
+        # shellcheck disable=SC2016
+        error_exit 'The `scc` command is unavailable.'
+    fi
+}
+
+
+error_exit() {
+    # Echo error message and exit with error
+    echo -e "${E31}ERROR:${E0} ${*}" 1>&2
+    exit 1
+}
+
+
+header() {
+    # Print 80 character wide black on white heading with time
+    printf "${E30}${E107} %-71s$(date '+%T') ${E0}\n" "${@}"
+}
+
+
+print_key_val() {
+    local _sep
+    if (( ${#1} > 10 ))
+    then
+        _sep="\n    "
+    else
+        _sep=' '
+    fi
+    printf "${E97}${E100}%21s${E0}${_sep}%s\n" "${1}:" "${2}"
+}
+
+
+print_var() {
+    print_key_val "${1}" "${!1}"
+}
+
+
+published_documents() {
+    local _count
+    header 'Published'
+    print_var DIR_PUB_LICENSES
+    print_var DIR_PUB_PUBLICDOMAIN
+    echo
+
+    echo "${E1}Legal Tools${E0}"
+    # licenses
+    _count=$(find "${DIR_PUB_LICENSES}" \
+        -type f -name 'deed.en.html' \
+        | wc -l \
+        | sed -e's/[[:space:]]*//g')
+    printf "  %-13s%'4d\n" "Licenses" "${_count}"
+    # public domain
+    _count=$(find "${DIR_PUB_PUBLICDOMAIN}" \
+        -type f -name 'deed.en.html' \
+        | wc -l \
+        | sed -e's/[[:space:]]*//g')
+    printf "  ${E4}%-13s%'4d${E0}\n" "Public domain" "${_count}"
+    # total
+    _count=$(find "${DIR_PUB_LICENSES}" "${DIR_PUB_PUBLICDOMAIN}" \
+        -type f -name 'deed.en.html' \
+        | wc -l \
+        | sed -e's/[[:space:]]*//g')
+    printf "  %-13s%'4d\n" "Total" "${_count}"
+    echo
+
+    echo "${E1}Documents${E0}"
+    # licenses
+    _count=$(find "${DIR_PUB_LICENSES}" \
+        -type f \( -name '*.html' -o -name 'rdf' \) \
+        | wc -l \
+        | sed -e's/[[:space:]]*//g')
+    printf "  %-13s% '7d\n" "Licenses" "${_count}"
+    # public domain
+    _count=$(find "${DIR_PUB_PUBLICDOMAIN}" \
+        -type f \( -name '*.html' -o -name 'rdf' \) \
+        | wc -l \
+        | sed -e's/[[:space:]]*//g')
+    printf "  ${E4}%-13s% '7d${E0}\n" "Public domain" "${_count}"
+    # total
+    _count=$(find "${DIR_PUB_LICENSES}" "${DIR_PUB_PUBLICDOMAIN}" \
+        -type f \( -name '*.html' -o -name 'rdf' \) \
+        | wc -l \
+        | sed -e's/[[:space:]]*//g')
+    printf "  %-13s% '7d\n" "Total" "${_count}"
+    echo
+}
+
+
+source_code() {
+    header 'Source code'
+    print_var DIR_REPO
+    cd "${DIR_REPO}"
+    scc \
+        --exclude-dir .git,wp-content \
+        --no-duplicates \
+        --dryness
+    echo
+}
+
+
+todo() {
+    header 'Deeds & UX translation'
+    echo "${E33}TODO${E0}"
+    echo
+    header 'Legal Code translation'
+    echo "${E33}TODO${E0}"
+    echo
+}
+
+
+#### MAIN #####################################################################
+
+check_prerequisites
+source_code
+published_documents
+todo


### PR DESCRIPTION
## Description
Add About section to README and stats script
- Rendered README:
  - old/current [`README.md`](https://github.com/creativecommons/cc-legal-tools-app/blob/c0bef3620397acd7cd5693e36d1c60096c4dc27d/README.md)
  - new/PR [`README.md`](https://github.com/creativecommons/cc-legal-tools-app/blob/ef26cfe3f85802c5333a7c91d9ba9849ecd2064c/README.md)

## Technical details
- [boyter/scc](https://github.com/boyter/scc): Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go

## Tests
N/A - no changes to Django app

## Stats output example

<img width="491" alt="Screenshot 2024-05-06 at 10 38 27" src="https://github.com/creativecommons/cc-legal-tools-app/assets/691322/3fe3070f-8311-4920-aeae-b03005cd877a">


<details>
<summary>plaintext output</summary>

```
 Source code                                                            10:39:37 
            DIR_REPO: /Users/timidrobot/git/creativecommons/cc-legal-tools-app
───────────────────────────────────────────────────────────────────────────────
Language                 Files     Lines   Blanks  Comments     Code Complexity
───────────────────────────────────────────────────────────────────────────────
Python                      53     17802      486       610    16706        223
(ULOC)                              8780
-------------------------------------------------------------------------------
HTML                        35      4067      363        15     3689          0
(ULOC)                              2015
-------------------------------------------------------------------------------
Shell                       12       978      122        84      772         51
(ULOC)                               508
-------------------------------------------------------------------------------
YAML                         6       205       36        25      144          0
(ULOC)                               123
-------------------------------------------------------------------------------
Markdown                     5      1382      397         0      985          0
(ULOC)                               882
-------------------------------------------------------------------------------
CSS                          3       350       21        10      319          0
(ULOC)                               221
-------------------------------------------------------------------------------
Plain Text                   2        29        7         0       22          0
(ULOC)                                23
-------------------------------------------------------------------------------
CSV                          1         1        0         0        1          0
(ULOC)                                 2
-------------------------------------------------------------------------------
Dockerfile                   1        63       15        18       30          0
(ULOC)                                48
-------------------------------------------------------------------------------
JavaScript                   1         7        1         0        6          0
(ULOC)                                 7
-------------------------------------------------------------------------------
License                      1        21        4         0       17          0
(ULOC)                                18
-------------------------------------------------------------------------------
TOML                         1        65        0         2       63          0
(ULOC)                                55
───────────────────────────────────────────────────────────────────────────────
Total                      121     24970     1452       764    22754        274
───────────────────────────────────────────────────────────────────────────────
Unique Lines of Code (ULOC)        12650
DRYness %                           0.51
───────────────────────────────────────────────────────────────────────────────
Estimated Cost to Develop (organic) $718,631
Estimated Schedule Effort (organic) 12.13 months
Estimated People Required (organic) 5.26
───────────────────────────────────────────────────────────────────────────────
Processed 888601 bytes, 0.889 megabytes (SI)
───────────────────────────────────────────────────────────────────────────────


 Published                                                              10:39:37 
    DIR_PUB_LICENSES:
    /Users/timidrobot/git/creativecommons/cc-legal-tools-data/docs/licenses
DIR_PUB_PUBLICDOMAIN:
    /Users/timidrobot/git/creativecommons/cc-legal-tools-data/docs/publicdomain

Legal Tools
  Licenses      636
  Public domain   3
  Total         639

Documents
  Licenses      32,142
  Public domain    220
  Total         32,362

 Deeds & UX translation                                                 10:39:38 
TODO

 Legal Code translation                                                 10:39:38 
TODO
```

</details>

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
