### PR TITLE
App: redirects for deeds with absent languages

### DIFF
--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -556,13 +556,10 @@ class Command(BaseCommand):
                     "RewriteCond %{REQUEST_FILENAME}.html !-f",
                     "RewriteCond %{REQUEST_FILENAME} !-l",
                     "RewriteCond %{REQUEST_FILENAME}.html !-l",
-                    f"RewriteRule licenses/([a-z+-]+)/{ver}/"
-                    f"{jur}/deed[.].*$"
+                    f"RewriteRule licenses/([a-z+-]+)/{ver}/{jur}/deed[.].*$"
                     f" /licenses/$1/{ver}/{jur}/deed.{default_lang} [R=301,L]",
                 ]
-        # DISABLED until generated file has been moved to within inside
-        #          directory stanza in Apache2 config
-        # DISABLED  include_lines += step2_lines
+        include_lines += step2_lines
         del step2_lines
 
         # Step 3: Redirect absent deed translations for international/universal
@@ -592,9 +589,7 @@ class Command(BaseCommand):
             " /licenses/$1/$2/deed.en [R=301,L]",
             "",
         ]
-        # DISABLED until generated file has been moved to within inside
-        #          directory stanza in Apache2 config
-        # DISABLED  include_lines += step3_lines
+        include_lines += step3_lines
         del step3_lines
 
         include_lines.append("# vim: ft=apache ts=4 sw=4 sts=4 sr noet")


### PR DESCRIPTION
## Fixes
- Fixes #236 by @TimidRobot 

## Description
App: redirects for deeds with absent languages
- generate contextual redirects for deed URLs of languages that would otherwise 404

Also see related Data PR:
- creativecommons/cc-legal-tools-data#200

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
Tested with [creativecommons/index-dev-env](https://github.com/creativecommons/index-dev-env/):
```
HTTP/1.1 301  http://localhost:8080/licenses/by-nc-nd/1.0/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by-nd-nc/1.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by-nd-nc/1.0/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by-nd-nc/1.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/sampling/1.0/br/deed.apy
>>>>>>>> 200  http://localhost:8080/licenses/sampling/1.0/br/deed.pt-br
HTTP/1.1 301  http://localhost:8080/licenses/sampling+/1.0/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/sampling+/1.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by-nc-sa/2.0/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by-nc-sa/2.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by-nc/2.0/be/deed.wa
>>>>>>>> 200  http://localhost:8080/licenses/by-nc/2.0/be/deed.fr
HTTP/1.1 301  http://localhost:8080/licenses/by-nd/2.1/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by-nd/2.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by-sa/2.1/jp/deed.ryn
>>>>>>>> 200  http://localhost:8080/licenses/by-sa/2.1/jp/deed.ja
HTTP/1.1 301  http://localhost:8080/licenses/by/2.5/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by/2.5/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by/2.5/ar/deed.gn
>>>>>>>> 200  http://localhost:8080/licenses/by/2.5/ar/deed.es
HTTP/1.1 301  http://localhost:8080/licenses/by/3.0/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by/3.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by/3.0/am/deed.hy
>>>>>>>> 200  http://localhost:8080/licenses/by/3.0/am/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by/3.0/es/deed.ast
>>>>>>>> 200  http://localhost:8080/licenses/by/3.0/es/deed.es
HTTP/1.1 301  http://localhost:8080/licenses/by/4.0/deed.INVALID
>>>>>>>> 200  http://localhost:8080/licenses/by/4.0/deed.en
HTTP/1.1 301  http://localhost:8080/licenses/by/4.0/deed.mi
>>>>>>>> 200  http://localhost:8080/licenses/by/4.0/deed.en
```

command:
```shell
./dev/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1690      0    638      0  100.00%

20 files skipped due to complete coverage.
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
