### PR TITLE
App: improve clarity of legal tool title

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -54,12 +54,27 @@ div.masthead > nav.ancilliary-menu span.locale.icon-attach:before {
 /* header title */
 /* TODO: resolve with vocabulary-theme */
 .cc-legal-tools main > header {
+  align-items: center;  /* deed display: flex */
   padding: 3em 0;
+}
+.cc-legal-tools,.bidi-left main > header > span.tool-icons {
+  padding-right: 1em;
+  height: 2em;
+}
+.cc-legal-tools,.bidi-right main > header > span.tool-icons {
+  padding-left: 1em;
 }
 .cc-legal-tools main > header > span.tool-icons > span.cc-icon > svg {
   display: inline;
-  height: 4em;
-  width: 4em;
+  height: 2em;
+  width: 2em;
+  vertical-align: text-bottom;  /* legalcode display: block */
+}
+.cc-legal-tools main > header > span.tool-identifier {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 2.1em;
 }
 .cc-legal-tools main > header > h1 {
   margin: 0.2em 0;

--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -54,33 +54,39 @@ div.masthead > nav.ancilliary-menu span.locale.icon-attach:before {
 /* header title */
 /* TODO: resolve with vocabulary-theme */
 .cc-legal-tools main > header {
-  align-items: center;  /* deed display: flex */
+  align-items: center;
+  /* (upstream vocabulary default-page class uses display: box) */
+  display: flex;
   padding: 3em 0;
 }
-.cc-legal-tools,.bidi-left main > header > span.tool-icons {
-  padding-right: 1em;
-  height: 2em;
+.cc-legal-tools,.bidi-left main > header > span.alt-titles {
+  order: 1;
 }
-.cc-legal-tools,.bidi-right main > header > span.tool-icons {
+.cc-legal-tools,.bidi-left main > header > span.alt-titles > span.tool-icons {
+  padding-right: 1em;
+}
+.cc-legal-tools,.bidi-right main > header > span.alt-titles > span.tool-icons {
   padding-left: 1em;
 }
-.cc-legal-tools main > header > span.tool-icons > span.cc-icon > svg {
+main > header > span.alt-titles > span.tool-icons > span.cc-icon > svg {
   display: inline;
   height: 2em;
   width: 2em;
-  vertical-align: text-bottom;  /* legalcode display: block */
+  vertical-align: text-bottom;
 }
-.cc-legal-tools main > header > span.tool-identifier {
+.cc-legal-tools main > header > span.alt-titles > span.tool-identifier {
   font-family: 'Roboto Condensed';
+  font-size: 2.1em;
   font-style: normal;
   font-weight: 700;
-  font-size: 2.1em;
 }
 .cc-legal-tools main > header > h1 {
   margin: 0.2em 0;
+  order: 2;
 }
 .cc-legal-tools main > header > h2 {
   margin: 0;
+  order: 3;
 }
 
 

--- a/cc_legal_tools/static/cc-legal-tools/deed.css
+++ b/cc_legal_tools/static/cc-legal-tools/deed.css
@@ -3,6 +3,7 @@
   border-bottom: 5px solid var(--vocabulary-neutral-color-dark-gray);
   border-left: 5px solid var(--vocabulary-neutral-color-dark-gray);
   border-right: 5px solid var(--vocabulary-neutral-color-dark-gray);
+  margin-top: 2em;
   margin-left: -3em;
   margin-right: -3em;
   padding-left: 3em;

--- a/dev/stats.sh
+++ b/dev/stats.sh
@@ -55,7 +55,7 @@ error_exit() {
 
 header() {
     # Print 80 character wide black on white heading with time
-    printf "${E30}${E107} %-71s$(date '+%T') ${E0}\n" "${@}"
+    printf "${E30}${E107}# %-70s$(date '+%T') ${E0}\n" "${@}"
 }
 
 

--- a/templates/includes/snippet/title_with_icons.html
+++ b/templates/includes/snippet/title_with_icons.html
@@ -7,8 +7,8 @@
     </svg>
   </span>
   {% endfor %}
-  {{ tool.identifier }}
 </span>
+<span class="tool-identifier">{{ tool.identifier }}</span>
 <h1>{{ tool_title }}</h2>
 <h2>
   {% if document_type == "deed" %}

--- a/templates/includes/snippet/title_with_icons.html
+++ b/templates/includes/snippet/title_with_icons.html
@@ -1,15 +1,17 @@
 {% load i18n %}
-<span class="tool-icons">
-  {% for code in tool.logos %}
-  <span class="cc-icon">
-    <svg viewBox="0 0 30 30">
-      <use href="/wp-content/themes/vocabulary-theme/vocabulary/svg/cc/icons/cc-icons.svg#{{ code }}"></use>
-    </svg>
+<h1>{{ tool_title }}</h1>
+<span class="alt-titles">
+  <span class="tool-icons">
+    {% for code in tool.logos %}
+    <span class="cc-icon">
+      <svg viewBox="0 0 30 30">
+        <use href="/wp-content/themes/vocabulary-theme/vocabulary/svg/cc/icons/cc-icons.svg#{{ code }}"></use>
+      </svg>
+    </span>
+    {% endfor %}
   </span>
-  {% endfor %}
+  <span class="tool-identifier">{{ tool.identifier }}</span>
 </span>
-<span class="tool-identifier">{{ tool.identifier }}</span>
-<h1>{{ tool_title }}</h2>
 <h2>
   {% if document_type == "deed" %}
     {% trans "Deed" %}

--- a/templates/includes/snippet/title_with_icons.html
+++ b/templates/includes/snippet/title_with_icons.html
@@ -7,13 +7,14 @@
     </svg>
   </span>
   {% endfor %}
+  {{ tool.identifier }}
 </span>
-<h1>
+<h1>{{ tool_title }}</h2>
+<h2>
   {% if document_type == "deed" %}
-    {{ tool.identifier }} {% trans "Deed" %}
+    {% trans "Deed" %}
   {% else %}
-    {{ tool.identifier }} {% trans "Legal Code" %}
+     {% trans "Legal Code" %}
   {% endif %}
-</h1>
-<h2>{{ tool_title }}</h2>
+</h2>
 {# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}


### PR DESCRIPTION
## Fixes

We've received reports that people are confused about the title of the legal tools with the current design.
- For example, for the **Attribution-NonCommercial-NoDerivs 4.0 International** legal tool, users may think the title is:
  - **CC BY-NC-ND 4.0 Deed**
  - **CC BY-NC-ND 4.0 Legal Code**

Looking at the screenshots, below, it is easy to see how the current design leads to confusion.

Related to:
- creativecommons/index-prototype#66

## Description
App: improve clarity of legal tool title

Also see related Data PR:
- creativecommons/cc-legal-tools-data#202

Thank you @possumbilities for help with CSS and HTML!


## Technical details
- [Basic concepts of flexbox - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
- Properties
  - [align-items - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
  - [display - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
  - [vertical-align - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)

## Tests
command:
```shell
./dev/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1690      0    638      0  100.00%

20 files skipped due to complete coverage.
```

## Screenshots

### Deed

| Old/current | New/PR |
| --- | --- |
|  ![Screenshot 2024-05-30 at 09-10-18 CC BY-NC-ND 4 0 Deed Attribution-NonCommercial-NoDerivs 4 0 International Creative Commons](https://github.com/creativecommons/cc-legal-tools-app/assets/691322/2dfe81e3-a299-44a9-a263-7f9fab2a882d) | ![Screenshot 2024-05-30 at 09-11-01 CC BY-NC-ND 4 0 Deed Attribution-NonCommercial-NoDerivs 4 0 International Creative Commons](https://github.com/creativecommons/cc-legal-tools-app/assets/691322/40689f51-d0c7-42b4-be17-0d00309e8ddc) |

### Legal Code

| Old/current | New/PR |
| --- | --- |
| ![Screenshot 2024-05-30 at 09-10-27 CC BY-NC-ND 4 0 Legal Code Attribution-NonCommercial-NoDerivs 4 0 International Creative Commons](https://github.com/creativecommons/cc-legal-tools-app/assets/691322/3c9178c4-d265-46cf-bd1c-e3b7448f8ad3) | ![Screenshot 2024-05-30 at 09-11-07 CC BY-NC-ND 4 0 Legal Code Attribution-NonCommercial-NoDerivs 4 0 International Creative Commons](https://github.com/creativecommons/cc-legal-tools-app/assets/691322/5ee47a61-f150-4cf6-8028-80ba7259a439) |

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the *default* branch of the repository (`main` or `master`).
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
