### PR TITLE
App: improve clarity and consistency of HTML head titles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
 <head about="{% block head_about %}{% endblock %}">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}{% endblock %} | Creative Commons</title>
+  <title>{% block title %}{% endblock %} - Creative Commons</title>
   <link href="{{ canonical_url_html }}" rel="canonical">
 {% for option in languages_and_links %}
 {% if option.cc_language_code == language_default %}

--- a/templates/deed.html
+++ b/templates/deed.html
@@ -6,7 +6,7 @@
 {% block body_class%}walkthrough-page{% endblock %}
 
 {% block title %}
-{{ tool.identifier }} {% trans "Deed" %} | {{ tool_title }}
+{% trans "Deed" %} - {{ tool_title }}
 {% endblock %}
 
 

--- a/templates/legalcode.html
+++ b/templates/legalcode.html
@@ -3,7 +3,7 @@
 
 
 {% block title %}
-{{ tool.identifier }} {% trans "Legal Code" %} | {{ tool_title }}
+{% trans "Legal Code" %} - {{ tool_title }}
 {% endblock %}
 
 


### PR DESCRIPTION
## Description
App: improve clarity and consistency of HTML head titles
- use dash (`-`) as a deliminator  to match the rest of CreativeCommons.org instead of ~~pipe (`|`)~~
  - dashes provide a better experience for people using a screen reader
- drop tool identifier (ex. CC BY-NC-SA 4.0) as it is redundant and no longer matches the layout of the title on the page

Also see related Data pull request:
- creativecommons/cc-legal-tools-data#216

## Technical details
Additional discussion on title delimiters:
- creativecommons/tech-support#1093 (private repo)

<!---
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!---
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
