### PR TITLE
App: improve title translation, add caching, enable debug toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 
 # Unit test / coverage reports
 .coverage*
+htmlcov
 
 # Django development
 */settings/local.py

--- a/cc_legal_tools/settings/base.py
+++ b/cc_legal_tools/settings/base.py
@@ -116,13 +116,13 @@ TEMPLATES = [
     },
 ]
 
-# template_fragments
-# For our use case, caching doesn't appear to offer any benefits and only adds
-# complexity. This was determined by testing both publishing speed and page
-# speed.
+# The caching API is used, but there are no caching MIDDLEWARE, above, as we
+# are not using site caching (which adds overhead without benefit for our uses)
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "TIMEOUT": 600,
+        "OPTIONS": {"CULL_FREQUENCY": 0, "MAX_ENTRIES": 3000},
     },
 }
 

--- a/cc_legal_tools/settings/dev.py
+++ b/cc_legal_tools/settings/dev.py
@@ -54,6 +54,7 @@ if (
     #      can set DEBUG_TOOLBAR_CONFIG['IS_RUNNING_TESTS'] = False to bypass
     #      this check.
     DEBUG = True
+    DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG}
     INSTALLED_APPS += [  # noqa: F405
         "debug_toolbar",
     ]

--- a/cc_legal_tools/settings/dev.py
+++ b/cc_legal_tools/settings/dev.py
@@ -57,6 +57,6 @@ if (
     INSTALLED_APPS += [  # noqa: F405
         "debug_toolbar",
     ]
-    MIDDLEWARE += (  # noqa: F405
+    MIDDLEWARE += [  # noqa: F405
         "debug_toolbar.middleware.DebugToolbarMiddleware",
-    )
+    ]

--- a/cc_legal_tools/urls.py
+++ b/cc_legal_tools/urls.py
@@ -48,5 +48,5 @@ if settings.DEBUG:
     import debug_toolbar
 
     urlpatterns += [
-        path("__debug__/", include("debug_toolbar.urls")),
+        path("__debug__/", include(debug_toolbar.urls)),
     ]

--- a/cc_legal_tools/urls.py
+++ b/cc_legal_tools/urls.py
@@ -48,5 +48,5 @@ if settings.DEBUG:
     import debug_toolbar
 
     urlpatterns += [
-        re_path(r"^__debug__/", include(debug_toolbar.urls)),
+        path("__debug__/", include("debug_toolbar.urls")),
     ]

--- a/dev/coverage.sh
+++ b/dev/coverage.sh
@@ -2,38 +2,63 @@
 #
 # Run coverage tests and report
 #
-set -o errtrace
-set -o nounset
-
 # This script passes all arguments to Coverage Tests. For example, it can be
 # called from the cc-legal-tools-app directory like so:
 #
 #     ./dev/coverage.sh --failfast
 
-# Change directory to cc-legal-tools-app (grandparent directory of this script)
-cd ${0%/*}/../
+set -o errexit
+set -o errtrace
+set -o nounset
 
-if ! docker compose exec app true 2>/dev/null; then
-    echo 'The app container/services is not avaialable.' 1>&2
-    echo 'First run `docker compose up`.' 1>&2
+# shellcheck disable=SC2154
+trap '_es=${?};
+    printf "${0}: line ${LINENO}: \"${BASH_COMMAND}\"";
+    printf " exited with a status of ${_es}\n";
+    exit ${_es}' ERR
+
+DIR_REPO="$(cd -P -- "${0%/*}/.." && pwd -P)"
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+E0="$(printf "\e[0m")"        # reset
+E30="$(printf "\e[30m")"      # black foreground
+E31="$(printf "\e[31m")"      # red foreground
+E107="$(printf "\e[107m")"    # bright white background
+
+#### FUNCTIONS ################################################################
+
+error_exit() {
+    # Echo error message and exit with error
+    echo -e "${E31}ERROR:${E0} ${*}" 1>&2
     exit 1
-fi
+}
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'Coverage Erase'
-docker compose exec app coverage erase
-echo 'done.'
+print_header() {
+    # Print 80 character wide black on white heading with time
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
+}
+
+#### MAIN #####################################################################
+
+cd "${DIR_REPO}"
+
+docker compose exec app true 2>/dev/null \
+    || error_exit \
+        'The Docker app container/service is not avaialable. See README.md'
+
+print_header 'Coverage Erase'
+docker compose exec app coverage erase --debug=dataio
 echo
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'Coverage Tests'
-docker compose exec app coverage run \
+print_header 'Coverage Tests'
+docker compose exec app coverage run --debug=pytest \
     manage.py test --noinput --parallel 4 ${@:-} \
     || exit
 echo
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'Coverage Combine'
+print_header 'Coverage Combine'
 docker compose exec app coverage combine
 echo
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'Coverage Report'
+print_header 'Coverage Report'
 docker compose exec app coverage report
 echo

--- a/dev/coverage.sh
+++ b/dev/coverage.sh
@@ -45,20 +45,24 @@ docker compose exec app true 2>/dev/null \
     || error_exit \
         'The Docker app container/service is not avaialable. See README.md'
 
-print_header 'Coverage Erase'
+print_header 'Coverage erase'
 docker compose exec app coverage erase --debug=dataio
 echo
 
-print_header 'Coverage Tests'
+print_header 'Coverage tests'
 docker compose exec app coverage run --debug=pytest \
     manage.py test --noinput --parallel 4 ${@:-} \
     || exit
 echo
 
-print_header 'Coverage Combine'
+print_header 'Coverage combine'
 docker compose exec app coverage combine
 echo
 
-print_header 'Coverage Report'
+print_header 'Coverage html'
+docker compose exec app coverage html
+echo
+
+print_header 'Coverage report'
 docker compose exec app coverage report
 echo

--- a/dev/stats.sh
+++ b/dev/stats.sh
@@ -53,9 +53,9 @@ error_exit() {
 }
 
 
-header() {
+print_header() {
     # Print 80 character wide black on white heading with time
-    printf "${E30}${E107}# %-70s$(date '+%T') ${E0}\n" "${@}"
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
 }
 
 
@@ -78,7 +78,7 @@ print_var() {
 
 published_documents() {
     local _count _subtotal _ver
-    header 'Published'
+    print_header 'Published'
     print_var DIR_PUB_LICENSES
     print_var DIR_PUB_PUBLICDOMAIN
     echo
@@ -185,7 +185,7 @@ published_documents() {
 
 
 source_code() {
-    header 'Source code'
+    print_header 'Source code'
     print_var DIR_REPO
     cd "${DIR_REPO}"
     scc \
@@ -197,10 +197,10 @@ source_code() {
 
 
 todo() {
-    header 'Deeds & UX translation'
+    print_header 'Deeds & UX translation'
     echo "${E33}TODO${E0}"
     echo
-    header 'Legal Code translation'
+    print_header 'Legal Code translation'
     echo "${E33}TODO${E0}"
     echo
 }

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -191,6 +191,8 @@ JURISDICTION_NAMES = {
     "za": gettext_lazy("South Africa"),
 }
 UNIT_NAMES = {
+    # 4.0 licenses use "NoDerivatives" instead of "NoDerivs". When appropriate,
+    # the following values are updated by legal_tools.views.get_tool_title()
     "by": gettext_lazy("Attribution"),
     "by-nc": gettext_lazy("Attribution-NonCommercial"),
     "by-nc-nd": gettext_lazy("Attribution-NonCommercial-NoDerivs"),

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -389,6 +389,79 @@ class ToolsTestsMixin:
         super().setUp()
 
 
+class ViewHelperFunctionsTest(ToolsTestsMixin, TestCase):
+    def test_get_category_and_category_title_category_tool(self):
+        category, category_title = get_category_and_category_title(
+            category=None,
+            tool=None,
+        )
+        self.assertEqual(category, "licenses")
+        self.assertEqual(category_title, "Licenses")
+
+        tool = Tool.objects.get(unit="by", version="4.0")
+        category, category_title = get_category_and_category_title(
+            category=None,
+            tool=tool,
+        )
+        self.assertEqual(category, "licenses")
+        self.assertEqual(category_title, "Licenses")
+
+    def test_get_category_and_category_title_category_publicdomain(self):
+        category, category_title = get_category_and_category_title(
+            category="publicdomain",
+            tool=None,
+        )
+        self.assertEqual(category, "publicdomain")
+        self.assertEqual(category_title, "Public Domain")
+
+    @override_settings(LANGUAGES_MOSTLY_TRANSLATED=["x1", "x2"])
+    def test_get_deed_rel_path_mostly_translated_language_code(self):
+        expected_deed_rel_path = "deed.x1"
+        deed_rel_path = get_deed_rel_path(
+            deed_url="/deed.x1",
+            path_start="/",
+            language_code="x1",
+            language_default="x2",
+        )
+        self.assertEqual(expected_deed_rel_path, deed_rel_path)
+
+    @override_settings(LANGUAGES_MOSTLY_TRANSLATED=["x1", "x2"])
+    def test_get_deed_rel_path_less_translated_language_code(self):
+        expected_deed_rel_path = "deed.x2"
+        deed_rel_path = get_deed_rel_path(
+            deed_url="/deed.x3",
+            path_start="/",
+            language_code="x3",
+            language_default="x2",
+        )
+        self.assertEqual(expected_deed_rel_path, deed_rel_path)
+
+    @override_settings(
+        LANGUAGE_CODE="x1",
+        LANGUAGES_MOSTLY_TRANSLATED=[],
+    )
+    def test_get_deed_rel_path_less_translated_language_default(self):
+        expected_deed_rel_path = "deed.x1"
+        deed_rel_path = get_deed_rel_path(
+            deed_url="/deed.x3",
+            path_start="/",
+            language_code="x3",
+            language_default="x2",
+        )
+        self.assertEqual(expected_deed_rel_path, deed_rel_path)
+
+    def test_normalize_path_and_lang(self):
+        request_path = "/licenses/by/3.0/de/legalcode"
+        jurisdiction = "de"
+        norm_request_path, norm_language_code = normalize_path_and_lang(
+            request_path,
+            jurisdiction,
+            language_code=None,
+        )
+        self.assertEqual(norm_request_path, f"{request_path}.de")
+        self.assertEqual(norm_language_code, "de")
+
+
 class ViewDevHomeTest(ToolsTestsMixin, TestCase):
     def test_view_dev_index_view(self):
         url = reverse("dev_index")
@@ -785,81 +858,6 @@ class ViewLegalCodeTest(TestCase):
     #        context = rsp.context
     #        self.assertContains(rsp, 'lang="de"')
     #        self.assertEqual(lc, context["legal_code"])
-
-    def test_get_category_and_category_title_category_tool(self):
-        category, category_title = get_category_and_category_title(
-            category=None,
-            tool=None,
-        )
-        self.assertEqual(category, "licenses")
-        self.assertEqual(category_title, "Licenses")
-
-        tool = ToolFactory(
-            category="licenses",
-            base_url="https://creativecommons.org/licenses/by/4.0/",
-            version="4.0",
-        )
-        category, category_title = get_category_and_category_title(
-            category=None,
-            tool=tool,
-        )
-        self.assertEqual(category, "licenses")
-        self.assertEqual(category_title, "Licenses")
-
-    def test_get_category_and_category_title_category_publicdomain(self):
-        category, category_title = get_category_and_category_title(
-            category="publicdomain",
-            tool=None,
-        )
-        self.assertEqual(category, "publicdomain")
-        self.assertEqual(category_title, "Public Domain")
-
-    def test_normalize_path_and_lang(self):
-        request_path = "/licenses/by/3.0/de/legalcode"
-        jurisdiction = "de"
-        norm_request_path, norm_language_code = normalize_path_and_lang(
-            request_path,
-            jurisdiction,
-            language_code=None,
-        )
-        self.assertEqual(norm_request_path, f"{request_path}.de")
-        self.assertEqual(norm_language_code, "de")
-
-    @override_settings(LANGUAGES_MOSTLY_TRANSLATED=["x1", "x2"])
-    def test_get_deed_rel_path_mostly_translated_language_code(self):
-        expected_deed_rel_path = "deed.x1"
-        deed_rel_path = get_deed_rel_path(
-            deed_url="/deed.x1",
-            path_start="/",
-            language_code="x1",
-            language_default="x2",
-        )
-        self.assertEqual(expected_deed_rel_path, deed_rel_path)
-
-    @override_settings(LANGUAGES_MOSTLY_TRANSLATED=["x1", "x2"])
-    def test_get_deed_rel_path_less_translated_language_code(self):
-        expected_deed_rel_path = "deed.x2"
-        deed_rel_path = get_deed_rel_path(
-            deed_url="/deed.x3",
-            path_start="/",
-            language_code="x3",
-            language_default="x2",
-        )
-        self.assertEqual(expected_deed_rel_path, deed_rel_path)
-
-    @override_settings(
-        LANGUAGE_CODE="x1",
-        LANGUAGES_MOSTLY_TRANSLATED=[],
-    )
-    def test_get_deed_rel_path_less_translated_language_default(self):
-        expected_deed_rel_path = "deed.x1"
-        deed_rel_path = get_deed_rel_path(
-            deed_url="/deed.x3",
-            path_start="/",
-            language_code="x3",
-            language_default="x2",
-        )
-        self.assertEqual(expected_deed_rel_path, deed_rel_path)
 
     def test_view_legal_code_identifying_jurisdiction_default_language(self):
         language_code = "de"

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -119,12 +119,12 @@ def get_tool_title(unit, version, category, jurisdiction, language_code):
         cache.add(f"{prefix}title", tool_title)
         return tool_title
 
-    # Translate title using legal code translation domain
+    # Translate title using legal code translation domain for legal code that
+    # is in Transifex (ex. CC0, Licenses 4.0)
     if (
         category == "licenses"
         and version not in ("1.0", "2.0", "2.1", "2.5", "3.0")
     ) or unit == "zero":
-        # Translate title parts using legal code translation domain
         slug = f"{unit}_{version}".replace(".", "")
         language_default = get_default_language_for_jurisdiction_naive(
             jurisdiction
@@ -136,7 +136,8 @@ def get_tool_title(unit, version, category, jurisdiction, language_code):
         with active_translation(current_translation):
             tool_title_lc = translation.gettext(tool_title_en)
         # Only use legal code translation domain version if translation
-        # was successful (does not match English)
+        # was successful (does not match English). There are deed translations
+        # in languages for which we do not yet have legal code translations.
         if tool_title_lc != tool_title_en:
             tool_title = tool_title_lc
             cache.add(f"{prefix}title", tool_title)

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -15,7 +15,6 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
 from django.utils import translation
-from django.utils.text import format_lazy
 
 # First-party/Local
 from i18n import UNIT_NAMES
@@ -24,6 +23,7 @@ from i18n.utils import (
     get_default_language_for_jurisdiction_deed,
     get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
+    get_translation_object,
     load_deeds_ux_translations,
     map_django_to_transifex_language_code,
 )
@@ -85,59 +85,70 @@ def get_category_and_category_title(category=None, tool=None):
     return category, category_title
 
 
-def get_tool_title(legal_code):
-    tool = legal_code.tool
-    prefix = (
-        f"{tool.unit}-{tool.version}-{tool.jurisdiction_code}"
-        f"-{legal_code.language_code}-"
-    )
+def get_tool_title_en(unit, version, category, jurisdiction):
+    prefix = f"{unit}-{version}-{jurisdiction}-en-"
+    tool_title_en = cache.get(f"{prefix}title", "")
+    if tool_title_en:
+        return tool_title_en
+
+    # Retrieve title parts untranslated (English)
+    with translation.override(None):
+        tool_name = str(UNIT_NAMES.get(unit, "UNIMPLEMENTED"))
+        jurisdiction_name = str(
+            get_jurisdiction_name(category, unit, version, jurisdiction)
+        )
+    # Licenses before 4.0 use "NoDerivs" instead of "NoDerivatives"
+    if version not in ("1.0", "2.0", "2.1", "2.5", "3.0"):
+        tool_name = tool_name.replace("NoDerivs", "NoDerivatives")
+    tool_title_en = f"{tool_name} {version} {jurisdiction_name}".strip()
+
+    cache.add(f"{prefix}title", tool_title_en)
+    return tool_title_en
+
+
+def get_tool_title(unit, version, category, jurisdiction, language_code):
+    prefix = f"{unit}-{version}-{jurisdiction}-{language_code}-"
     tool_title = cache.get(f"{prefix}title", "")
     if tool_title:
         return tool_title
-    tool_name = ""
-    jurisdiction_name = ""
-    # Default title translation (uses Deeds & UX translation domain)
-    tool_name = UNIT_NAMES.get(tool.unit, "UNIMPLEMENTED")
-    jurisdiction_name = get_jurisdiction_name(
-        tool.category, tool.unit, tool.version, tool.jurisdiction_code
-    )
-    tool_title = format_lazy(
-        "{tool_name} {tool_version} {jurisdiction_name}",
-        tool_name=tool_name,
-        tool_version=tool.version,
-        jurisdiction_name=jurisdiction_name,
-    )
-    # Attempt to override title with translation from legal code translation
-    # domain for tools that support full translation (Licenses 4.0 and CC0)
-    # always:
+
+    # English is easy given it is the default
+    tool_title_en = get_tool_title_en(unit, version, category, jurisdiction)
+    if language_code == "en":
+        tool_title = tool_title_en
+        cache.add(f"{prefix}title", tool_title)
+        return tool_title
+
+    # Translate title using legal code translation domain
     if (
-        tool.category == "licenses" and tool.version == "4.0"
-    ) or tool.unit == "zero":
-        tool_title_en = ""
-        tool_title_lc = ""
-        # Retrieve title parts untranslated (English)
-        with translation.override(None):
-            # Licenses before 4.0 use "NoDerivs" instead of "NoDerivatives"
-            tool_name = str(
-                UNIT_NAMES.get(tool.unit, "UNIMPLEMENTED")
-            ).replace("NoDerivs", "NoDerivatives")
-            jurisdiction_name = str(
-                get_jurisdiction_name(
-                    tool.category,
-                    tool.unit,
-                    tool.version,
-                    tool.jurisdiction_code,
-                )
-            )
-        tool_title_en = (
-            f"{tool_name} {tool.version} {jurisdiction_name}".strip()
-        )
+        category == "licenses"
+        and version not in ("1.0", "2.0", "2.1", "2.5", "3.0")
+    ) or unit == "zero":
         # Translate title parts using legal code translation domain
-        current_translation = legal_code.get_translation_object()
+        slug = f"{unit}_{version}".replace(".", "")
+        language_default = get_default_language_for_jurisdiction_naive(
+            jurisdiction
+        )
+        current_translation = get_translation_object(
+            slug, language_code, language_default
+        )
+        tool_title_lc = ""
         with active_translation(current_translation):
             tool_title_lc = translation.gettext(tool_title_en)
+        # Only use legal code translation domain version if translation
+        # was successful (does not match English)
         if tool_title_lc != tool_title_en:
             tool_title = tool_title_lc
+            cache.add(f"{prefix}title", tool_title)
+            return tool_title
+
+    # Translate title using Deeds & UX translation domain
+    with translation.override(language_code):
+        tool_name = UNIT_NAMES.get(unit, "UNIMPLEMENTED")
+        jurisdiction_name = get_jurisdiction_name(
+            category, unit, version, jurisdiction
+        )
+        tool_title = f"{tool_name} {version} {jurisdiction_name}"
 
     cache.add(f"{prefix}title", tool_title)
     return tool_title
@@ -264,16 +275,22 @@ def get_legal_code_replaced_rel_path(
             legal_code = LegalCode.objects.valid().get(
                 tool=tool, language_code=settings.LANGUAGE_CODE
             )
-    title = get_tool_title(legal_code)
+    title = get_tool_title(
+        tool.unit,
+        tool.version,
+        tool.category,
+        tool.jurisdiction_code,
+        legal_code.language_code,
+    )
     prefix = (
-        f"{legal_code.tool.unit}-{legal_code.tool.version}-"
-        f"{legal_code.tool.jurisdiction_code}-{legal_code.language_code}-"
+        f"{tool.unit}-{tool.version}-"
+        f"{tool.jurisdiction_code}-{legal_code.language_code}-"
     )
     replaced_deed_title = cache.get(f"{prefix}replaced_deed_title", "")
     if not replaced_deed_title:
         deed_str = cache.get(f"{prefix}deed_str", "")
         if not deed_str:
-            with translation.override(language_code):
+            with translation.override(legal_code.language_code):
                 deed_str = translation.gettext("Deed")
                 cache.add(f"{prefix}deed_str", deed_str)
         replaced_deed_title = f"{deed_str} - {title}"
@@ -290,7 +307,7 @@ def get_legal_code_replaced_rel_path(
     if not replaced_legal_code_title:
         legal_code_str = cache.get(f"{prefix}legal_code_str", "")
         if not legal_code_str:
-            with translation.override(language_code):
+            with translation.override(legal_code.language_code):
                 legal_code_str = translation.gettext("Legal Code")
                 cache.add(f"{prefix}legal_code_str", legal_code_str)
         replaced_legal_code_title = f"{legal_code_str} - {title}"
@@ -438,7 +455,9 @@ def view_list(request, category, language_code=None):
     )
     if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
         raise Http404(f"invalid language: {language_code}")
+
     translation.activate(language_code)
+
     list_licenses, list_publicdomain = get_list_paths(language_code, None)
     # Get the list of units and languages that occur among the tools
     # to let the template iterate over them as it likes.
@@ -558,20 +577,16 @@ def view_deed(
         return view_page_not_found(
             request, Http404(f"invalid language: {language_code}")
         )
-    translation.activate(language_code)
 
     path_start = os.path.dirname(request.path)
     language_default = get_default_language_for_jurisdiction_deed(jurisdiction)
-
-    list_licenses, list_publicdomain = get_list_paths(
-        language_code, language_default
-    )
 
     try:
         tool = Tool.objects.get(
             unit=unit, version=version, jurisdiction_code=jurisdiction
         )
     except Tool.DoesNotExist as e:
+        translation.activate(language_code)
         return view_page_not_found(request, e)
 
     try:
@@ -590,16 +605,25 @@ def view_deed(
                 settings.LANGUAGE_CODE
             )
 
-    tool_title = get_tool_title(legal_code)
+    tool_title = get_tool_title(
+        unit, version, category, jurisdiction, language_code
+    )
 
     legal_code_rel_path = os.path.relpath(
         legal_code.legal_code_url, path_start
+    )
+
+    translation.activate(language_code)
+
+    list_licenses, list_publicdomain = get_list_paths(
+        language_code, language_default
     )
 
     category, category_title = get_category_and_category_title(
         category,
         tool,
     )
+
     languages_and_links = get_languages_and_links_for_deeds_ux(
         request_path=request.path,
         selected_language_code=language_code,
@@ -709,7 +733,9 @@ def view_legal_code(
 
     # get_tool_title manipulates the translation domain and, therefore, MUST
     # be called before we Activate Legal Code translation
-    tool_title = get_tool_title(legal_code)
+    tool_title = get_tool_title(
+        unit, version, category, jurisdiction, language_code
+    )
     # get_legal_code_replaced_rel_path calls get_tool_title, see note above
     _, _, replaced_title, replaced_path = get_legal_code_replaced_rel_path(
         tool.is_replaced_by,

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -288,11 +288,8 @@ def get_legal_code_replaced_rel_path(
     )
     replaced_deed_title = cache.get(f"{prefix}replaced_deed_title", "")
     if not replaced_deed_title:
-        deed_str = cache.get(f"{prefix}deed_str", "")
-        if not deed_str:
-            with translation.override(legal_code.language_code):
-                deed_str = translation.gettext("Deed")
-                cache.add(f"{prefix}deed_str", deed_str)
+        with translation.override(legal_code.language_code):
+            deed_str = translation.gettext("Deed")
         replaced_deed_title = f"{deed_str} - {title}"
         cache.add(f"{prefix}replaced_deed_title", replaced_deed_title)
     replaced_deed_path = get_deed_rel_path(
@@ -305,11 +302,8 @@ def get_legal_code_replaced_rel_path(
         f"{prefix}replaced_legal_code_title", ""
     )
     if not replaced_legal_code_title:
-        legal_code_str = cache.get(f"{prefix}legal_code_str", "")
-        if not legal_code_str:
-            with translation.override(legal_code.language_code):
-                legal_code_str = translation.gettext("Legal Code")
-                cache.add(f"{prefix}legal_code_str", legal_code_str)
+        with translation.override(legal_code.language_code):
+            legal_code_str = translation.gettext("Legal Code")
         replaced_legal_code_title = f"{legal_code_str} - {title}"
         cache.add(
             f"{prefix}replaced_legal_code_title", replaced_legal_code_title

--- a/manage.py
+++ b/manage.py
@@ -1,25 +1,15 @@
 #!/usr/bin/env python
 # Standard library
 import logging
-import os
 import sys
+
+# Third-party
+from django.core.management import execute_from_command_line
 
 LOG = logging.getLogger("management.commands")
 
 
 def main():
-    if "DATABASE_URL" in os.environ:
-        os.environ.setdefault(
-            "DJANGO_SETTINGS_MODULE", "cc_legal_tools.settings.deploy"
-        )
-    else:
-        os.environ.setdefault(
-            "DJANGO_SETTINGS_MODULE", "cc_legal_tools.settings.local"
-        )
-
-    # Third-party
-    from django.core.management import execute_from_command_line
-
     execute_from_command_line(sys.argv)
 
 

--- a/templates/includes/legalcode_contextual_menu.html
+++ b/templates/includes/legalcode_contextual_menu.html
@@ -3,7 +3,7 @@
 <nav>
 <ul>
 <li>
-<a href="#legal-code-title">{% trans legal_code.title %}</a>
+<a href="#legal-code-title">{{ tool_title }}</a>
 <ul>
 
 

--- a/templates/includes/legalcode_licenses_4.0.html
+++ b/templates/includes/legalcode_licenses_4.0.html
@@ -1,7 +1,7 @@
 {% load bidi i18n license_tags %}
 <div id="legal-code-body">
 
-<h2 id="legal-code-title">{% trans legal_code.title %}</h2>
+<h2 id="legal-code-title">{{ tool_title }}</h2>
 
 <p>
 {% if legal_code|is_one_of:"by" %}

--- a/templates/includes/legalcode_zero.html
+++ b/templates/includes/legalcode_zero.html
@@ -1,6 +1,6 @@
 {% load bidi i18n license_tags %}
 <div id="legal-code-body">
-<h2 id="legal-code-title">{% trans legal_code.title %}</h2>
+<h2 id="legal-code-title">{{ tool_title }}</h2>
 
 {# section - untitled #}
 <p>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #439

## Description
App: improve title translation, add caching, enable debug toolbar
- standardize title generation to a single function so that titles are consistent throughout each document
  - prioritize legal code translation domain over Deeds & UX translation domain
  - add caching so additional overhead only causes a ~30 seconds of additional processing time on a full publish, instead of an additional ~6 minutes
    - (additional overhead is most significantly caused by older tools loading a legal code translation domain so they can recommend using the newer tool by title.)
  - update title formula per previous pull request:
    - #465
  - (this update is also necessary to support new translation workflow with Transifex as the source of legal code translations instead of legacy HTML files)
- remove unused code from `manage.py`
- improve `dev/coverage.sh`
  - update to use my common bash script conventions
  - add HTML report generation to make test writing easier to debug
- improve `dev/stats.sh`
  - improve consistency of my common bash script conventions
- properly enable the Django debug toolbar

Also see Data pull request:
- creativecommons/cc-legal-tools-data#217

## Technical details
- [Local-memory caching | Django’s cache framework | Django documentation | Django](https://docs.djangoproject.com/en/4.2/topics/cache/#local-memory-caching)
- There is at least one occurrence when the Deeds & UX translation domain is used instead of the appropriate legal code translation domain
  | Language | Translation domain | Value |
  | --- | --- | --- |
  | English | _(source)_ |  `CC0 1.0 Universal` |
  | German | Legal code (`zero_10`) |  `CC0 1.0 Universal` |
  | German | Deeds & UX (`django`) |  **`CC0 1.0 Universell`** |
  - The code compares the legal code translation to English and falls back to Deeds & UX translation if it matches. Because the legal code translation uses the same spelling as English, it is depriortized 🤷🏻 
  - The code must fallback to the Deeds &  UX translation because the deeds are translated into languages that the legal code has not yet been translated into.
  
## Tests
command:
```shell
./dev/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1721      0    660      0  100.00%

20 files skipped due to complete coverage.
```

## Screenshots

The following screenshots show the Django Debug Toolbar cache details panel for `http://127.0.0.1:8005/licenses/by/3.0/deed.en` (Deed - Attribution 3.0 Unported - Creative Commons):

### First render with cache misses
![Screenshot 2024-07-15 at 05-50-07 Deed - Attribution 3 0 Unported - Creative Commons](https://github.com/user-attachments/assets/26f54339-e7be-445c-8f03-c4c128c48962)

### Subsequent render with cache hits
![Screenshot 2024-07-15 at 05-50-19 Deed - Attribution 3 0 Unported - Creative Commons](https://github.com/user-attachments/assets/739139f5-de51-49bd-bcfb-77b1b99001d0)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
