### PR TITLE
Removed site navigation from licenses/ and publicdomain/ on print

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -262,4 +262,12 @@ main > aside > nav ul > li { /* TODO: resolve with vocabulary-theme */
   .cc-legal-tools > header {
     display: none;
   }
+
+  .cc-legal-tools main {
+    display: block;
+  }
+  
+  .cc-legal-tools main > aside {
+    display: none;
+  }
 }

--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -255,3 +255,11 @@ main > aside > nav ul > li { /* TODO: resolve with vocabulary-theme */
   margin-left: .3em;
   margin-right: 0;
 }
+
+/* print media */
+@media print {
+  .cc-legal-tools > footer,
+  .cc-legal-tools > header {
+    display: none;
+  }
+}

--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -266,7 +266,7 @@ main > aside > nav ul > li { /* TODO: resolve with vocabulary-theme */
   .cc-legal-tools main {
     display: block;
   }
-  
+
   .cc-legal-tools main > aside {
     display: none;
   }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Related to #281 by @TimidRobot 

## Description

This pull request hides the site and in-page navigation from pages in `licenses/` and `publicdomain/` when printed. I've tested my changes in Firefox, Chrome, Opera, and Microsoft Edge. 

## Technical details

I added a media query to hide the sitewide header and footer elements when printed to `base.css`. 

## Tests

To verify:
1. Compile the static site
2. Navigate to http://127.0.0.1:8006/licenses/list.en and go to any of the legal code or deed pages
3. Open the print dialog
4. Confirm the site wide header and footer, as well as the in page navigation (if originally present) are gone.

## Screenshots

### Before

Site Header
![image](https://github.com/user-attachments/assets/35fab8f1-143d-4025-9a0a-7b2b61ccaa95)
Site Footer
![image](https://github.com/user-attachments/assets/a819f966-6489-4d80-a607-94b9f70ed531)
In page navigation
![image](https://github.com/user-attachments/assets/a826af15-d31a-4413-81e1-1aa1c9a3b6dd)

### After
No site header
![image](https://github.com/user-attachments/assets/df7af3c9-bbeb-412b-bf1a-1901ea199a61)
No site footer
![image](https://github.com/user-attachments/assets/e653b4d6-ad78-464d-b2ed-4202911888e3)
No side navigation
![image](https://github.com/user-attachments/assets/7efb2cbc-87a6-4be7-abcb-ff1542703d98)

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
