### PR TITLE
[Bug] Fix Logo Overlap with Menu Button on Small Screen Sizes (e.g., iPhone SE)

### DIFF
--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
@@ -2610,7 +2610,7 @@ body > footer .license svg {
     button.expand-menu {
         position: absolute;
         top: 4.5em;
-        right: 0;
+        right: -2rem;
         display: inline-block;
         padding: .3em .5em;
         border: none;
@@ -2621,7 +2621,7 @@ body > footer .license svg {
         font-style: normal;
         font-weight: 700;
         font-size: 1em;
-        padding: 0rem 1rem;
+        padding: 0.5rem 1rem;
     }
 
     .primary-menu {

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
@@ -2621,7 +2621,7 @@ body > footer .license svg {
         font-style: normal;
         font-weight: 700;
         font-size: 1em;
-        padding: .5rem 1rem;
+        padding: 0rem 1rem;
     }
 
     .primary-menu {


### PR DESCRIPTION
## Fixes
- Fixes #418 by author @oka4shi 

## Description
In the responsive design, when the screen size is approximately 340px by 425px or when viewed on mobile devices like the iPhone SE, the logo (.identity-logo) is partially by the menu button. This causes a visual overlap that affects the aesthetic and usability of the interface.

The issue occurs because the current dimensions of the logo are too large for the limited space available at these screen widths. Adjusting the size of the logo or menu button and ensuring proper spacing can resolve the overlap and maintain a clean, professional appearance on smaller devices.

**Steps to Reproduce:**

Open the website on a screen size of 340px by 425px or on an iPhone SE.
Observe the overlap between the logo and the menu button in the header section.

## Tests
## Screenshots

### Before fixing it 

![image](https://github.com/user-attachments/assets/0ac65bf9-1bb4-4cce-8c3d-37083737031e)

---

### After fixing it 

![image](https://github.com/user-attachments/assets/6ab5d8b9-03f3-4fb4-bb2f-dd37cb56a965)



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
