### PR TITLE
Fixes #448 : Improve legal code language selection/fallback

### DIFF
--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -14,7 +14,7 @@ from django.test import TestCase, override_settings
 from i18n.utils import (
     active_translation,
     get_default_language_for_jurisdiction_deed_ux,
-    get_default_language_for_jurisdiction_naive,
+    get_default_language_for_jurisdiction_legal_code,
     get_jurisdiction_name,
     get_pofile_creation_date,
     get_pofile_path,
@@ -181,12 +181,12 @@ class I18NTest(TestCase):
     def test_get_language_for_jurisdiction_legal_code(self):
         # "be" jurisdiction default is "fr"
         self.assertEqual(
-            "fr", get_default_language_for_jurisdiction_naive("be")
+            "fr", get_default_language_for_jurisdiction_legal_code("be")
         )
         # "xx" is an invalid jurisdiction
         # return global default ("en")
         self.assertEqual(
-            "en", get_default_language_for_jurisdiction_naive("xx")
+            "en", get_default_language_for_jurisdiction_legal_code("xx")
         )
 
 

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -13,7 +13,7 @@ from django.test import TestCase, override_settings
 # First-party/Local
 from i18n.utils import (
     active_translation,
-    get_default_language_for_jurisdiction_deed,
+    get_default_language_for_jurisdiction_deed_ux,
     get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
     get_pofile_creation_date,
@@ -164,18 +164,18 @@ class I18NTest(TestCase):
     def test_get_language_for_jurisdiction_deed(self):
         # "be" jurisdiction default is "fr"
         self.assertEqual(
-            "fr", get_default_language_for_jurisdiction_deed("be")
+            "fr", get_default_language_for_jurisdiction_deed_ux("be")
         )
         # "am" jurisdiction default is "hy"
         # the "hy" translation is incomplete so we return the global default
         # https://github.com/creativecommons/cc-legal-tools-app/issues/444
         self.assertEqual(
-            "en", get_default_language_for_jurisdiction_deed("am")
+            "en", get_default_language_for_jurisdiction_deed_ux("am")
         )
         # "xx" is an invalid jurisdiction
         # return global default ("en")
         self.assertEqual(
-            "en", get_default_language_for_jurisdiction_deed("xx")
+            "en", get_default_language_for_jurisdiction_deed_ux("xx")
         )
 
     def test_get_language_for_jurisdiction_legal_code(self):
@@ -192,7 +192,7 @@ class I18NTest(TestCase):
 
 class TranslationTest(TestCase):
     @override_settings(
-        LANGUAGES_MOSTLY_TRANSLATED=["LANGUAGE_CODE"],
+        LANGUAGES_AVAILABLE_DEEDS_UX=["LANGUAGE_CODE"],
         LEGAL_CODE_LOCALE_PATH="LOCALE_DIRS",
     )
     def test_get_translation_object_specified_translated(self):
@@ -219,7 +219,7 @@ class TranslationTest(TestCase):
         self.assertEqual(translation_object, result)
 
     @override_settings(
-        LANGUAGES_MOSTLY_TRANSLATED=["LANGUAGE_DEFAULT"],
+        LANGUAGES_AVAILABLE_DEEDS_UX=["LANGUAGE_DEFAULT"],
         LEGAL_CODE_LOCALE_PATH="LOCALE_DIRS",
     )
     def test_get_translation_object_default_translated(self):
@@ -246,7 +246,7 @@ class TranslationTest(TestCase):
         self.assertEqual(translation_object, result)
 
     @override_settings(
-        LANGUAGES_MOSTLY_TRANSLATED=[],
+        LANGUAGES_AVAILABLE_DEEDS_UX=[],
         LEGAL_CODE_LOCALE_PATH="LOCALE_DIRS",
     )
     def test_get_translation_object_untranslated(self):

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -89,11 +89,11 @@ def get_translation_object(
 
     # Add a fallback to the standard Django translation for this language. This
     # gets us the non-legal-code parts of the pages.
-    if language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if language_code in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         tool_translation_object.add_fallback(
             translation.trans_real.translation(language_code)
         )
-    elif language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    elif language_default in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         tool_translation_object.add_fallback(
             translation.trans_real.translation(language_default)
         )
@@ -253,11 +253,11 @@ def map_legacy_to_django_language_code(legacy_language_code: str) -> str:
     return django_language_code
 
 
-def get_default_language_for_jurisdiction_deed(jurisdiction_code):
+def get_default_language_for_jurisdiction_deed_ux(jurisdiction_code):
     default_language = DEFAULT_JURISDICTION_LANGUAGES.get(
         jurisdiction_code, settings.LANGUAGE_CODE
     )
-    if default_language in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if default_language in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         return default_language
     else:
         return settings.LANGUAGE_CODE
@@ -310,7 +310,7 @@ def load_deeds_ux_translations():
     that meet or exceed the TRANSLATION_THRESHOLD).
     """
     deeds_ux_po_file_info = {}
-    languages_mostly_translated = []
+    languages_available_deeds_ux = []
     for language_code, pofile_path in get_deeds_ux_pofiles():
         pofile_obj = polib.pofile(pofile_path)
         percent_translated = pofile_obj.percent_translated()
@@ -326,12 +326,12 @@ def load_deeds_ux_translations():
             and language_code != settings.LANGUAGE_CODE
         ):
             continue
-        languages_mostly_translated.append(language_code)
+        languages_available_deeds_ux.append(language_code)
     deeds_ux_po_file_info = dict(sorted(deeds_ux_po_file_info.items()))
     # Add global settings
     settings.DEEDS_UX_PO_FILE_INFO = deeds_ux_po_file_info
-    settings.LANGUAGES_MOSTLY_TRANSLATED = sorted(
-        list(set(languages_mostly_translated))
+    settings.LANGUAGES_AVAILABLE_DEEDS_UX = sorted(
+        list(set(languages_available_deeds_ux))
     )
 
 

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -262,12 +262,59 @@ def get_default_language_for_jurisdiction_deed_ux(jurisdiction_code):
     else:
         return settings.LANGUAGE_CODE
 
-
-def get_default_language_for_jurisdiction_naive(jurisdiction_code):
-    return DEFAULT_JURISDICTION_LANGUAGES.get(
+def get_default_language_for_jurisdiction_legal_code(jurisdiction_code):
+    default_language = DEFAULT_JURISDICTION_LANGUAGES.get(
         jurisdiction_code, settings.LANGUAGE_CODE
     )
+    if default_language in settings.LANGUAGES_AVAILABLE_LEGAL_CODE:
+        return default_language
+    else:
+        return settings.LANGUAGE_CODE
 
+def get_legal_code_pofiles():
+    legal_code_pofiles = []
+    for locale_name in os.listdir(settings.LEGAL_CODE_LOCALE_PATH):
+        language_code = translation.to_language(locale_name)
+        pofile_path = get_pofile_path(
+            locale_or_legalcode="locale",
+            language_code=language_code,
+            translation_domain="django",
+        )
+        if not os.path.isfile(pofile_path):  # pragma: no cover
+            continue
+        legal_code_pofiles.append([language_code, pofile_path])
+    legal_code_pofiles.sort(key=lambda x: x[0])
+    return legal_code_pofiles
+
+def load_legal_code_translations():
+    """
+    Process Deed & UX translations (store information on all and track those
+    that meet or exceed the TRANSLATION_THRESHOLD).
+    """
+    legal_code_po_file_info = {}
+    languages_available_legal_code = []
+    for language_code, pofile_path in get_legal_code_pofiles():
+        pofile_obj = polib.pofile(pofile_path)
+        percent_translated = pofile_obj.percent_translated()
+        legal_code_po_file_info[language_code] = {
+            "percent_translated": percent_translated,
+            "creation_date": get_pofile_creation_date(pofile_obj),
+            "revision_date": get_pofile_revision_date(pofile_obj),
+            "metadata": pofile_obj.metadata,
+        }
+        update_lang_info(language_code)
+        if (
+            percent_translated < settings.TRANSLATION_THRESHOLD
+            and language_code != settings.LANGUAGE_CODE
+        ):
+            continue
+        languages_available_legal_code.append(language_code)
+    logel_code_po_file_info = dict(sorted(legal_code_po_file_info.items()))
+    # Add global settings
+    settings.DEEDS_UX_PO_FILE_INFO = legal_code_po_file_info
+    settings.LANGUAGES_AVAILABLE_LEGAL_CODE = sorted(
+        list(set(languages_available_legal_code))
+    )
 
 def get_jurisdiction_name(category, unit, version, jurisdiction_code):
     # For details on nomenclature for unported licenses, see:

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -309,7 +309,7 @@ def load_legal_code_translations():
         ):
             continue
         languages_available_legal_code.append(language_code)
-    logel_code_po_file_info = dict(sorted(legal_code_po_file_info.items()))
+    legal_code_po_file_info = dict(sorted(legal_code_po_file_info.items()))
     # Add global settings
     settings.DEEDS_UX_PO_FILE_INFO = legal_code_po_file_info
     settings.LANGUAGES_AVAILABLE_LEGAL_CODE = sorted(

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 # First-party/Local
 from i18n import DEFAULT_CSV_FILE
 from i18n.utils import (
-    get_default_language_for_jurisdiction_deed,
+    get_default_language_for_jurisdiction_deed_ux,
     write_transstats_csv,
 )
 from legal_tools.git_utils import commit_and_push_changes, setup_local_branch
@@ -433,7 +433,7 @@ class Command(BaseCommand):
 
         arguments = []
         for category in ["licenses", "publicdomain"]:
-            for language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+            for language_code in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
                 arguments.append((output_dir, category, language_code))
         self.pool.starmap(save_list, arguments)
 
@@ -469,7 +469,7 @@ class Command(BaseCommand):
                     (output_dir, legal_code, self.options["apache_only"])
                 )
             for tool in tools:
-                for language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+                for language_code in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
                     deed_arguments.append(
                         (
                             output_dir,
@@ -487,7 +487,7 @@ class Command(BaseCommand):
                         default_languages_deeds[tool.version] = {}
                     default_languages_deeds[tool.version][
                         tool.jurisdiction_code
-                    ] = get_default_language_for_jurisdiction_deed(
+                    ] = get_default_language_for_jurisdiction_deed_ux(
                         tool.jurisdiction_code,
                     )
 

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -12,7 +12,7 @@ from django.utils import translation
 # First-party/Local
 from i18n import LANGMAP_DJANGO_TO_PCRE
 from i18n.utils import (
-    get_default_language_for_jurisdiction_deed,
+    get_default_language_for_jurisdiction_deed_ux,
     get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
     get_pofile_path,
@@ -554,7 +554,7 @@ class Tool(models.Model):
         """
         Return a dictionary with the metadata for this tool.
         """
-        language_default = get_default_language_for_jurisdiction_deed(
+        language_default = get_default_language_for_jurisdiction_deed_ux(
             self.jurisdiction_code
         )
         data = {}
@@ -601,7 +601,7 @@ class Tool(models.Model):
            correctly
         """
         juris_code = self.jurisdiction_code
-        language_default = get_default_language_for_jurisdiction_deed(
+        language_default = get_default_language_for_jurisdiction_deed_ux(
             juris_code
         )
         filename = f"deed.{language_code}.html"

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -13,7 +13,7 @@ from django.utils import translation
 from i18n import LANGMAP_DJANGO_TO_PCRE
 from i18n.utils import (
     get_default_language_for_jurisdiction_deed_ux,
-    get_default_language_for_jurisdiction_naive,
+    get_default_language_for_jurisdiction_legal_code,
     get_jurisdiction_name,
     get_pofile_path,
     get_translation_object,
@@ -249,7 +249,7 @@ class LegalCode(models.Model):
         language_code = self.language_code
         tool = self.tool
         juris_code = tool.jurisdiction_code
-        language_default = get_default_language_for_jurisdiction_naive(
+        language_default = get_default_language_for_jurisdiction_legal_code(
             juris_code
         )
         filename = f"legalcode.{self.language_code}.html"
@@ -348,7 +348,7 @@ class LegalCode(models.Model):
         return self.tool.resource_slug
 
     def get_translation_object(self):
-        language_default = get_default_language_for_jurisdiction_naive(
+        language_default = get_default_language_for_jurisdiction_legal_code(
             self.tool.jurisdiction_code
         )
         return get_translation_object(

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.translation.trans_real import DjangoTranslation
 
 # First-party/Local
-from i18n.utils import get_default_language_for_jurisdiction_deed
+from i18n.utils import get_default_language_for_jurisdiction_deed_ux
 from legal_tools.models import UNITS_LICENSES, LegalCode, Tool, build_path
 from legal_tools.rdf_utils import (
     convert_https_to_http,
@@ -417,7 +417,7 @@ class ViewHelperFunctionsTest(ToolsTestsMixin, TestCase):
         self.assertEqual(category, "publicdomain")
         self.assertEqual(category_title, "Public Domain")
 
-    @override_settings(LANGUAGES_MOSTLY_TRANSLATED=["x1", "x2"])
+    @override_settings(LANGUAGES_AVAILABLE_DEEDS_UX=["x1", "x2"])
     def test_get_deed_rel_path_mostly_translated_language_code(self):
         expected_deed_rel_path = "deed.x1"
         deed_rel_path = get_deed_rel_path(
@@ -428,7 +428,7 @@ class ViewHelperFunctionsTest(ToolsTestsMixin, TestCase):
         )
         self.assertEqual(expected_deed_rel_path, deed_rel_path)
 
-    @override_settings(LANGUAGES_MOSTLY_TRANSLATED=["x1", "x2"])
+    @override_settings(LANGUAGES_AVAILABLE_DEEDS_UX=["x1", "x2"])
     def test_get_deed_rel_path_less_translated_language_code(self):
         expected_deed_rel_path = "deed.x2"
         deed_rel_path = get_deed_rel_path(
@@ -441,7 +441,7 @@ class ViewHelperFunctionsTest(ToolsTestsMixin, TestCase):
 
     @override_settings(
         LANGUAGE_CODE="x1",
-        LANGUAGES_MOSTLY_TRANSLATED=[],
+        LANGUAGES_AVAILABLE_DEEDS_UX=[],
     )
     def test_get_deed_rel_path_less_translated_language_default(self):
         expected_deed_rel_path = "deed.x1"
@@ -461,7 +461,7 @@ class ViewHelperFunctionsTest(ToolsTestsMixin, TestCase):
         )
         path_start = "/licenses/by/3.0"
         language_code = "en"
-        language_default = get_default_language_for_jurisdiction_deed(None)
+        language_default = get_default_language_for_jurisdiction_deed_ux(None)
 
         cache.clear()
         self.assertFalse(cache.has_key("by-4.0--en-replaced_deed_str"))
@@ -909,7 +909,7 @@ class ViewLegalCodeTest(TestCase):
         self.assertEqual(lc, context["legal_code"])
 
     @override_settings(
-        LANGUAGES_MOSTLY_TRANSLATED=["ar", settings.LANGUAGE_CODE],
+        LANGUAGES_AVAILABLE_DEEDS_UX=["ar", settings.LANGUAGE_CODE],
     )
     def test_view_legal_code_40(self):
         tool = ToolFactory(
@@ -949,7 +949,7 @@ class ViewLegalCodeTest(TestCase):
                 self.assertContains(rsp, 'dir="rtl"')
 
     @override_settings(
-        LANGUAGES_MOSTLY_TRANSLATED=["es", settings.LANGUAGE_CODE],
+        LANGUAGES_AVAILABLE_DEEDS_UX=["es", settings.LANGUAGE_CODE],
     )
     def test_view_legal_code_30_default_translated(self):
         language_code = "ast"
@@ -973,7 +973,7 @@ class ViewLegalCodeTest(TestCase):
         self.assertContains(rsp, 'dir="ltr"')
 
     @override_settings(
-        LANGUAGES_MOSTLY_TRANSLATED=[settings.LANGUAGE_CODE],
+        LANGUAGES_AVAILABLE_DEEDS_UX=[settings.LANGUAGE_CODE],
     )
     def test_view_legal_code_30_default_untranslated(self):
         language_code = "ast"

--- a/legal_tools/utils.py
+++ b/legal_tools/utils.py
@@ -16,7 +16,7 @@ import legal_tools.models
 from i18n import UNIT_NAMES
 from i18n.utils import (
     active_translation,
-    get_default_language_for_jurisdiction_naive,
+    get_default_language_for_jurisdiction_legal_code,
     get_jurisdiction_name,
     get_translation_object,
     map_legacy_to_django_language_code,
@@ -145,7 +145,7 @@ def parse_legal_code_filename(filename):
     if jurisdiction:
         language_code = (
             language_code
-            or get_default_language_for_jurisdiction_naive(jurisdiction)
+            or get_default_language_for_jurisdiction_legal_code(jurisdiction)
         )
     else:
         language_code = language_code or settings.LANGUAGE_CODE
@@ -511,7 +511,7 @@ def update_title(options):
                 # Translate title using legal code translation domain for legal
                 # code that is in Transifex (ex. CC0, Licenses 4.0)
                 slug = f"{unit}_{version}".replace(".", "")
-                language_default = get_default_language_for_jurisdiction_naive(
+                language_default = get_default_language_for_jurisdiction_legal_code(
                     jurisdiction
                 )
                 current_translation = get_translation_object(

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -20,7 +20,7 @@ from django.utils import translation
 from i18n.utils import (
     active_translation,
     get_default_language_for_jurisdiction_deed_ux,
-    get_default_language_for_jurisdiction_naive,
+    get_default_language_for_jurisdiction_legal_code,
     get_jurisdiction_name,
     load_deeds_ux_translations,
     map_django_to_transifex_language_code,
@@ -258,11 +258,11 @@ def name_local(legal_code):
 def normalize_path_and_lang(request_path, jurisdiction, language_code):
     if not language_code:
         if "legalcode" in request_path:
-            language_code = get_default_language_for_jurisdiction_naive(
+            language_code = get_default_language_for_jurisdiction_legal_code(
                 jurisdiction
             )
         else:
-            language_code = get_default_language_for_jurisdiction_deed_ux(
+            language_code = get_default_language_for_jurisdiction_legal_code(
                 jurisdiction
             )
     if not request_path.endswith(f".{language_code}"):
@@ -403,7 +403,7 @@ def view_list(request, category, language_code=None):
         lc_unit = lc.tool.unit
         lc_version = lc.tool.version
         lc_identifier = lc.tool.identifier()
-        lc_language_default = get_default_language_for_jurisdiction_naive(
+        lc_language_default = get_default_language_for_jurisdiction_legal_code(
             lc.tool.jurisdiction_code,
         )
         lc_lang_code = lc.language_code
@@ -521,7 +521,7 @@ def view_deed(
             # Next, try to load legal code with default language for the
             # jurisdiction
             legal_code = tool.get_legal_code_for_language_code(
-                get_default_language_for_jurisdiction_naive(jurisdiction)
+                get_default_language_for_jurisdiction_legal_code(jurisdiction)
             )
         except LegalCode.DoesNotExist:
             # Last, load legal code with global default language (English)
@@ -619,7 +619,7 @@ def view_legal_code(
     request.path, language_code = normalize_path_and_lang(
         request.path, jurisdiction, language_code
     )
-    language_default = get_default_language_for_jurisdiction_naive(
+    language_default = get_default_language_for_jurisdiction_legal_code(
         jurisdiction
     )
 

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -19,7 +19,7 @@ from django.utils import translation
 # First-party/Local
 from i18n.utils import (
     active_translation,
-    get_default_language_for_jurisdiction_deed,
+    get_default_language_for_jurisdiction_deed_ux,
     get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
     load_deeds_ux_translations,
@@ -87,7 +87,7 @@ def get_category_and_category_title(category=None, tool=None):
 def get_languages_and_links_for_deeds_ux(request_path, selected_language_code):
     languages_and_links = []
 
-    for language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    for language_code in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         language_info = translation.get_language_info(language_code)
         link = request_path.replace(
             f".{selected_language_code}",
@@ -147,8 +147,8 @@ def get_deed_rel_path(
     language_default,
 ):
     deed_rel_path = os.path.relpath(deed_url, path_start)
-    if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
-        if language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if language_code not in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
+        if language_default in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
             # Translation incomplete, use region default language
             deed_rel_path = deed_rel_path.replace(
                 f"deed.{language_code}", f"deed.{language_default}"
@@ -167,8 +167,8 @@ def get_list_paths(language_code, language_default):
         f"/publicdomain/list.{language_code}",
     ]
     for index, path in enumerate(paths):
-        if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
-            if language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+        if language_code not in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
+            if language_default in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
                 # Translation incomplete, use region default language
                 paths[index] = path.replace(
                     f"/list.{language_code}", f"/list.{language_default}"
@@ -262,7 +262,7 @@ def normalize_path_and_lang(request_path, jurisdiction, language_code):
                 jurisdiction
             )
         else:
-            language_code = get_default_language_for_jurisdiction_deed(
+            language_code = get_default_language_for_jurisdiction_deed_ux(
                 jurisdiction
             )
     if not request_path.endswith(f".{language_code}"):
@@ -377,7 +377,7 @@ def view_list(request, category, language_code=None):
     request.path, language_code = normalize_path_and_lang(
         request.path, None, language_code
     )
-    if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if language_code not in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         raise Http404(f"invalid language: {language_code}")
 
     translation.activate(language_code)
@@ -497,13 +497,13 @@ def view_deed(
     request.path, language_code = normalize_path_and_lang(
         request.path, jurisdiction, language_code
     )
-    if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if language_code not in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         return view_page_not_found(
             request, Http404(f"invalid language: {language_code}")
         )
 
     path_start = os.path.dirname(request.path)
-    language_default = get_default_language_for_jurisdiction_deed(jurisdiction)
+    language_default = get_default_language_for_jurisdiction_deed_ux(jurisdiction)
 
     try:
         tool = Tool.objects.get(
@@ -647,9 +647,9 @@ def view_legal_code(
     )
 
     # Use Deeds & UX translations for title instead of Legal Code
-    if language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    if language_code in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         translation.activate(language_code)
-    elif language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+    elif language_default in settings.LANGUAGES_AVAILABLE_DEEDS_UX:
         translation.activate(language_default)
     else:
         translation.activate(settings.LANGUAGE_CODE)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #448 by @TimidRobot 

## Description
<!-- Concisely describe what the pull request does. -->
This pull request implements new functionality for managing legal code translations in the system, addressing the need for:
1. Populating the `settings.LANGUAGES_AVAILABLE_LEGAL_CODE` variable with legal code translations using a new function `load_legal_code_translations()`.
2. Adding a function `get_default_language_for_jurisdiction_legal_code()` to determine the default language for a given jurisdiction, considering the available legal code translations.
3. Rename function `get_default_language_for_jurisdiction_deed()` to `get_default_language_for_jurisdiction_deed_ux()`.
4. Rename variable `settings.LANGUAGES_MOSTLY_TRANSLATED` to `settings.LANGUAGES_AVAILABLE_DEEDS_UX`.

These additions align with the existing structure for deeds and UX translations, ensuring consistency across the system.
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
### New Functions
1. `load_legal_code_translations()`
* Iterates through legal code PO files obtained from `get_legal_code_pofiles()`.
* Calculates translation percentages and filters languages based on `settings.TRANSLATION_THRESHOLD`.
* Populates `settings.LANGUAGES_AVAILABLE_LEGAL_CODE` with languages meeting the criteria.
* Stores metadata for translations in `settings.DEEDS_UX_PO_FILE_INFO`.
2. `get_default_language_for_jurisdiction_legal_code()`
* Uses `DEFAULT_JURISDICTION_LANGUAGES` to determine the default language for a jurisdiction.
* Falls back to `settings.LANGUAGE_CODE` if the language is unavailable in `settings.LANGUAGES_AVAILABLE_LEGAL_CODE`.
3. `get_legal_code_pofiles()`
* Retrieves a sorted list of legal code PO files by iterating over directories in `settings.LEGAL_CODE_LOCALE_PATH`.
* Filters valid PO files based on their paths.

### Key Updates
* Ensured `settings.LANGUAGES_AVAILABLE_LEGAL_CODE` is dynamically populated during runtime for accurate jurisdiction language lookups.
* Replaced  `get_default_language_for_jurisdiction_naive()` function  with a `get_default_language_for_jurisdiction_legal_code()` function.
* Rename `settings.LANGUAGES_AVAILABLE_DEEDS_UX` to `settings.LANGUAGES_AVAILABLE_DEEDS_UX`
* The new functions follow the same structure and logic as existing deeds and UX translation functions, promoting code consistency and maintainability.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
