### PR TITLE
App: update `vocabulary-theme` to `v1.9.4`, update markup and localized stylings to accommodate changes

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -9,19 +9,19 @@
 }
 
 
-/* Ancilliary menu */
-.ancilliary-menu {
+/* Ancillary menu */
+.ancillary-menu {
   font-size: min(.8em, 2.5vw);
 }
-.bidi-left div.masthead > nav.ancilliary-menu {
+.bidi-left div.masthead > nav.ancillary-menu {
   left: auto;
   right: calc( -1 * var(--vocabulary-page-edges-space));
 }
-.bidi-right div.masthead > nav.ancilliary-menu {
+.bidi-right div.masthead > nav.ancillary-menu {
   left: 0;
   right: auto !important;
 }
-div.masthead > nav.ancilliary-menu span.locale {
+div.masthead > nav.ancillary-menu span.locale {
   display: inline-flex;
   align-items: center;
   margin-top: 5px;
@@ -31,20 +31,20 @@ div.masthead > nav.ancilliary-menu span.locale {
   border: none;
   border-radius: 3px;
 }
-div.masthead > nav.ancilliary-menu span.locale.icon-attach:before {
+div.masthead > nav.ancillary-menu span.locale.icon-attach:before {
   --icon-sprite: var(--fa-globe);
   --icon-sprite-size: .8em;
   opacity: .5;
 }
-.bidi-left div.masthead > nav.ancilliary-menu a.donate.icon-attach:before,
-.bidi-left div.masthead > nav.ancilliary-menu span.locale.icon-attach:before,
-.bidi-left div.masthead > nav.ancilliary-menu a.search.icon-attach:before {
+.bidi-left div.masthead > nav.ancillary-menu a.donate.icon-attach:before,
+.bidi-left div.masthead > nav.ancillary-menu span.locale.icon-attach:before,
+.bidi-left div.masthead > nav.ancillary-menu a.search.icon-attach:before {
   margin-left: 0;
   margin-right: .8em;
 }
-.bidi-right div.masthead > nav.ancilliary-menu a.donate.icon-attach:before,
-.bidi-right div.masthead > nav.ancilliary-menu span.locale.icon-attach:before,
-.bidi-right div.masthead > nav.ancilliary-menu a.search.icon-attach:before {
+.bidi-right div.masthead > nav.ancillary-menu a.donate.icon-attach:before,
+.bidi-right div.masthead > nav.ancillary-menu span.locale.icon-attach:before,
+.bidi-right div.masthead > nav.ancillary-menu a.search.icon-attach:before {
   margin-left: .8em;
   margin-right: 0;
 }

--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -62,13 +62,13 @@ div.masthead > nav.ancillary-menu span.locale.icon-attach:before {
   display: flex;
   padding: 3em 0;
 }
-.cc-legal-tools,.bidi-left main > header > span.alt-titles {
+.cc-legal-tools .bidi-left main > header > span.alt-titles {
   order: 1;
 }
-.cc-legal-tools,.bidi-left main > header > span.alt-titles > span.tool-icons {
+.cc-legal-tools .bidi-left main > header > span.alt-titles > span.tool-icons {
   padding-right: 1em;
 }
-.cc-legal-tools,.bidi-right main > header > span.alt-titles > span.tool-icons {
+.cc-legal-tools .bidi-right main > header > span.alt-titles > span.tool-icons {
   padding-left: 1em;
 }
 main > header > span.alt-titles > span.tool-icons > span.cc-icon > svg {

--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -96,6 +96,7 @@ main > header > span.alt-titles > span.tool-icons > span.cc-icon > svg {
 /* right nav */
 .cc-legal-tools main > aside {
   background-color: var(--vocabulary-brand-color-soft-gold);
+  margin-left: 4.1rem;
   padding: 1em;
   height: fit-content;
 }

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
@@ -3,7 +3,7 @@ Theme Name: CC Vocabulary Theme
 Author: the Creative Commons team; possumbilities, Timid Robot
 Author URI: https://opensource.creativecommons.org/
 Description: Theme based on the Vocabulary Design System
-Version: 1.7
+Version: 1.9.4
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.0
@@ -165,17 +165,17 @@ main nav.pagination ul li span.current {
 
 
 .home-narrative main {
-  width: 100%;
-  margin-top: 5.4em;
+  margin-top: 3.4em;
   margin-right: 0;
   margin-bottom: 0;
-  margin-left: 0;
-  padding: 0;
-  /* padding: 0 5%; */
 
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 400;
+}
+
+.home-narrative main > header {
+  margin-bottom: 0;
 }
 
 .home-narrative main > article > h2 {
@@ -203,12 +203,16 @@ main nav.pagination ul li span.current {
 }
 
 .home-narrative .topic-summary {
+  grid-column: 2 / span 9;
+  display: grid;
+  grid-template:
+      "title graphic graphic"
+      "description graphic graphic"
+      "button graphic graphic";
   display: grid;
   grid-template-columns: 1fr 1fr;
-  margin: 0 5%;
   margin-bottom: 6.4em;
   gap: 0 4em;
-
 }
 
 .home-narrative .topic-summary h2 {
@@ -226,7 +230,6 @@ main nav.pagination ul li span.current {
 
 .home-narrative .topic-summary figure {
   width: 100%;
-  /* height: 60%; */
   grid-area: graphic;
   margin: 0;
   padding: 0;
@@ -248,10 +251,8 @@ main nav.pagination ul li span.current {
 }
 
 .home-narrative .topic-summary .description a {
-  /* grid-area: button; */
   display: inline;
   box-sizing: border-box;
-  /* grid-area: none; */
   grid-column-start: 1;
   grid-row-start: 3;
 
@@ -261,6 +262,7 @@ main nav.pagination ul li span.current {
 }
 
 .home-narrative .case-studies {
+  grid-column: 1 / span 11;
   padding: 0 5%;
   padding-top: 3.5em;
   position: relative;
@@ -307,9 +309,7 @@ main nav.pagination ul li span.current {
 
 .home-narrative .case-studies footer {
   margin: 0 0;
-  /* margin-top: 6em; */
   margin-top: 4em;
-  /* margin-bottom: 6em; */
   margin-bottom: 3em;
   padding: 2em;
 
@@ -338,7 +338,7 @@ main nav.pagination ul li span.current {
 }
 
 .home-narrative .data-points .data-point.wikipedia h2 {
-  text-indent: -3000px;
+  text-indent: -10000px;
   min-height: 150px;
   background: center center no-repeat;
   background-size: contain;
@@ -347,7 +347,7 @@ main nav.pagination ul li span.current {
 }
 
 .home-narrative .data-points .data-point.the-met h2 {
-  text-indent: -3000px;
+  text-indent: -10000px;
   min-height: 150px;
   background: center center no-repeat;
   background-size: contain;
@@ -358,7 +358,7 @@ main nav.pagination ul li span.current {
 }
 
 .home-narrative .data-points .data-point.khan-academy h2 {
-  text-indent: -3000px;
+  text-indent: -10000px;
   min-height: 150px;
   width: 90%;
   background: center center no-repeat;
@@ -375,238 +375,126 @@ main nav.pagination ul li span.current {
   text-transform: uppercase;
 }
 
-
-
 .home-narrative .data-points .data-point p {
   margin-bottom: 0;
 
-  /* font-size: 1.2em; */
   font-size: 1em;
 }
 
-
-
-.home-narrative main .authored-posts {
-  /* display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  margin-top: 8em;
-  padding: 0 4em;
-  gap: 3em;
-  box-sizing: border-box; */
-  width: 60%;
-  margin: 0 auto;
-  margin-top: 8em;
-
-  background: var(--vocabulary-neutral-color-lighter-gray);
+.home-narrative main .posts {
+  grid-column: 2 / span 9;
+  padding-top: 4em;
 }
 
-.home-narrative main .authored-posts article {
-  margin-bottom: 4em;
-}
-
-.home-narrative main .authored-posts.highlight article header {
-  margin-top: 0;
-}
-
-.home-narrative main .authored-posts > h2 {
-  grid-column: span 12;
-  margin-top: 0;
-  margin-bottom: 0;
-  /* margin-bottom: 1em; */
-
+.home-narrative main .posts h2 {
   text-align: center;
 }
 
-.home-narrative main .authored-posts.highlight {
+.home-narrative main .posts ul {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(12, 1fr);
   margin-top: 8em;
-  padding: 6em 4em;
   gap: 2em;
   box-sizing: border-box;
-
   width:100%;
   margin: 0 auto;
   margin-top: 0;
-  /* padding: 0; */
 
-  /* background: var(--vocabulary-neutral-color-lighter-gray); */
-}
-
-.home-narrative main .authored-posts.highlight:nth-of-type(1) article {
-  /* margin-bottom: 6em; */
-  margin-bottom: 4em;
-}
-
-.home-narrative main .authored-posts.highlight article.story {
-  grid-column: span 3;
-}
-
-.home-narrative main .authored-posts.highlight article figure {
-  order: -1;
-
-}
-
-.home-narrative main .authored-posts.highlight article a {
-  --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-}
-
-.home-narrative main .authored-posts.highlight article h2, .home-narrative main .authored-posts.highlight article h3 {
-  font-size: 1.4em;
-}
-
-.home-narrative main .authored-posts.highlight > article:nth-of-type(1) {
-  grid-column: span 12;
-  margin-bottom: 1em;
-  padding: 4em;
-
-  background: var(--vocabulary-brand-color-soft-tomato);
-  /* background: var(--vocabulary-brand-color-soft-turquoise); */
-  background: white;
-  /* background: var(--vocabulary-neutral-color-lighter-gray); */
-  /* border-top: 2px solid black; */
-
-}
-
-.home-narrative main .authored-posts.highlight > article:nth-of-type(1) a {
-  --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
-  /* --underline-background-color: var(--vocabulary-brand-color-soft-turquoise); */
-  --underline-background-color: white;
-}
-
-.home-narrative main .authored-posts.highlight article:nth-of-type(1) h3 {
-  font-size: 2.1em;
-}
-
-.home-narrative main .authored-posts.highlight article:nth-of-type(1) figure {
-  order: initial;
-}
-
-.home-narrative main .authored-posts.highlight article:nth-of-type(1) p {
-  margin-bottom: 0;
-}
-
-.home-narrative main footer {
-  grid-column: span 12;
-  margin: 0 5%;
-  margin: 0;
-
-  text-align: center;
-}
-
-.home-narrative footer a.more {
-  display: inline-block;
-  margin: 0 auto;
-  margin-bottom: 4em;
-
-}
-
-.home-narrative .attribution-list {
-  position: relative;
-  padding: 4em;
-  gap: 0;
-
-
-  background:  var(--vocabulary-brand-color-soft-turquoise);
-  background: var(--vocabulary-brand-color-tomato);
-  background: var(--vocabulary-brand-color-soft-tomato);
-  background: var(--vocabulary-neutral-color-lighter-gray);
-  /* background: white; */
-  /* color: white; */
-  text-align: left;
-
-  border: 2px solid var(--vocabulary-neutral-color-dark-gray);
-}
-
-.home-narrative main .authored-posts.highlight article.attribution-list h2 {
-  margin: 0;
-  font-size: 2.1em;
-}
-
-.home-narrative main .authored-posts.highlight article.attribution-list ul {
-  margin-top: 2em;
-}
-
-.home-narrative >  h2 {
-  margin-top: 0;
-  font-size: 2.4em;
-}
-
-.home-narrative .attribution-list button.expand-attribution {
-  position: absolute;
-  top: 4.5em;
-  right: 4em;
-
-  cursor: pointer;
-  border: 1px solid black;
-  border-radius: 3px;
-  padding: .5em;
-  font-family: "Source Sans Pro";
-}
-
-.home-narrative .attribution-list button.expand-attribution.selected {
-  background: black;
-  color: white;
-}
-
-.home-narrative .attribution-list ul {
-  display: none;
-}
-
-.home-narrative .attribution-list ul.expand {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-  margin: 0;
-  padding: 0;
-  gap: 2em;
-
-  font-size: 1em;
+  font-size: 1rem;
   list-style: none;
 }
 
-.home-narrative .attribution-list article {
-  margin-bottom: 1em;
+.home-narrative main .posts ul li {
+  grid-column: span 4;
 }
 
-.home-narrative .attribution-list article article a {
-  /* --underline-background-color: var(--vocabulary-brand-color-tomato); */
-  /* color: white; */
+.home-narrative main .posts ul li h3 {
+  font-size: 1.5em;
+}
 
-  /* --underline-background-color: var(--vocabulary-brand-color-soft-tomato); */
+.home-narrative main .posts .post figure {
+  order: -1;
+}
 
+/* targets the featured posts section */
+.home-narrative main .posts.featured {
+  grid-column: 1 / span 11;
+  margin-bottom: 3em;
+
+  background: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+.home-narrative main .posts.featured .post h3 {
+  font-size: 1.4em;
+}
+
+.home-narrative main .posts.featured ul li:nth-child(1) h3 {
+  font-size: 2.1em;
+}
+
+.home-narrative main .posts.featured .post a {
   --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-
-
 }
 
-.home-narrative .attribution-list article figure {
-  display: flex;
-  gap: 1em;
-  margin-top: 1em;
+.home-narrative main .posts.featured li:nth-of-type(1) .post a {
+  --underline-background-color: white;
 }
 
-.home-narrative .attribution-list article img {
-  object-fit: cover;
-  width: 4em;
-  height: 4em;
+.home-narrative main .posts.featured li:nth-of-type(1) .post figure {
+  order: initial;
 }
 
-.home-narrative .attribution-list article figure .attribution {
-  margin-top: 0;
+.home-narrative main .posts.featured ul {    
+  padding: 0 var(--vocabulary-page-edges-space);
 }
 
+.home-narrative main .posts.featured ul li {
+  grid-column: span 3;
+}
+
+.home-narrative main .posts.featured ul li:nth-of-type(1) {
+  grid-column: span 12;
+
+  background: white;
+}
+
+.home-narrative main .posts.featured ul li:nth-of-type(1) article.post {
+  margin-bottom: 1em;
+  padding: 4em;
+}
+
+.home-narrative main > footer {
+  grid-column: 1 / span 11;
+  display: grid;
+  grid-template-columns: subgrid;
+  padding-top: 3em;
+  padding-bottom: 8em;
+
+  background: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+.home-narrative main > footer .attribution-list {
+  grid-column: 2 / span 9;
+
+  background: none;
+  border: 2px solid var(--vocabulary-neutral-color-dark-gray);
+}
 
 
 @media (min-width: 1500px) {
+
   .home-narrative .data-points .data-point.khan-academy h2 {
     text-indent: -6000px;
   }
+
 }
 
 @media (max-width: 1140px) {
+
   .home-narrative main footer .attribution-list ul.expand {
     grid-template-columns: 1fr 1fr;
   }
+
 }
 
 @media (max-width: 900px) {
@@ -631,29 +519,14 @@ main nav.pagination ul li span.current {
     /* padding: 0 1em; */
   }
 
-
-  .home-narrative main .authored-posts.highlight {
+  .home-narrative main .posts ul {
     display: flex;
     flex-wrap: wrap;
-    padding: 0 5%;
-    /* width: 90%; */
-
-  }
-
-  .home-narrative .authored-posts.highlight h2 {
-    margin-top: 1em;
-  }
-
-  .home-narrative main .authored-posts.highlight > article:nth-child(1) {
-    width: 100%;
-  }
-
-  .home-narrative .authored-posts article {
-    margin-bottom: 3em;
   }
 
   .home-narrative main footer {
     width: 100%;
+    box-sizing: border-box;
   }
 
 }
@@ -675,15 +548,33 @@ main nav.pagination ul li span.current {
   .home-narrative .data-points ul {
     display: block;
     padding-top: 2em;
-   }
+  }
 
-  .home-narrative main .authored-posts article {
-    margin-bottom: 2em;
+   .home-narrative main article.posts.featured > ul li:nth-child(1) {
+    padding: 2em;
+  }
+
+  .home-narrative main .posts {
+      padding: 0 var(--vocabulary-page-edges-space);
   }
 
   .home-narrative main footer .attribution-list ul.expand {
-    display: block;
+      display: block;
+  }
 }
+
+@media (max-width: 425px) {
+
+  .home-narrative .attribution-list {
+    padding: 2em;
+  }
+
+  .home-narrative .attribution-list h2 {
+    width: 50%;
+
+    hyphens: auto;
+    word-break: break-word;
+  }
 
 }
 
@@ -699,9 +590,7 @@ main nav.pagination ul li span.current {
 
 @media (max-width: 425px) {
 
-  .home-narrative main .authored-posts.highlight > article:nth-of-type(1) {
-    padding: 1.2em;
-  }
+
 
   .home-narrative .attribution-list {
     padding: 2em;
@@ -714,8 +603,14 @@ main nav.pagination ul li span.current {
     word-break: break-word;
 
   }
-
+  
 }
 
-
 /* patches */
+
+main > article figure img, main > figure img {
+  width: 100%;
+}
+main .content ul, main .content ol {
+    line-height: 150%;
+}

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
@@ -444,7 +444,7 @@ main nav.pagination ul li span.current {
   order: initial;
 }
 
-.home-narrative main .posts.featured ul {    
+.home-narrative main .posts.featured ul {
   padding: 0 var(--vocabulary-page-edges-space);
 }
 
@@ -603,7 +603,7 @@ main nav.pagination ul li span.current {
     word-break: break-word;
 
   }
-  
+
 }
 
 /* patches */

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
@@ -334,7 +334,7 @@ main > aside.sidebar nav.filter-menu ul li.current a {
 main > aside.sidebar nav ul {
     margin: 0;
     padding: 0;
-    
+
     text-indent: none;
     list-style: none;
     font-size: 1rem;
@@ -396,7 +396,7 @@ main h2 {
 
 main h3 {
     box-sizing: border-box;
-    
+
     font-family: 'Roboto Condensed';
     font-style: normal;
     font-weight: 700;
@@ -640,7 +640,7 @@ main article.posts.related .post header {
 
 main article.posts.related .post figure {
     display: none;
-    order: -1; 
+    order: -1;
 }
 
 main article.posts.related .post a {
@@ -666,7 +666,7 @@ main nav.pagination ol {
     width: 100%;
     margin: 0;
     padding: 0;
-    
+
     text-indent: none;
     font-size: 1em;
     list-style: none;
@@ -702,7 +702,7 @@ main .attribution-list {
     grid-column: 3 / span 7;
     box-sizing: border-box;
     position: relative;
-    padding: 4em; 
+    padding: 4em;
 
     background: var(--vocabulary-neutral-color-lighter-gray);
     text-align: left;
@@ -1525,7 +1525,7 @@ body > footer .license svg {
     order: initial;
 }
 
-.blog-index main .posts.featured ul {    
+.blog-index main .posts.featured ul {
     padding: 0 var(--vocabulary-page-edges-space);
 }
 
@@ -1957,7 +1957,7 @@ body > footer .license svg {
         padding: 0 var(--vocabulary-page-edges-space);
     }
 
-    main:has( > aside.sidebar) > aside.sidebar { 
+    main:has( > aside.sidebar) > aside.sidebar {
         padding: 0 var(--vocabulary-page-edges-space);
     }
 
@@ -1966,7 +1966,7 @@ body > footer .license svg {
     }
 
     main > .posts {
-        padding: 0 var(--vocabulary-page-edges-space); 
+        padding: 0 var(--vocabulary-page-edges-space);
     }
 
     .posts article figure {
@@ -1979,7 +1979,7 @@ body > footer .license svg {
         padding-right: var(--vocabulary-page-edges-space);
     }
 
-    .person-page main > header:before { 
+    .person-page main > header:before {
         left: 0;
     }
 
@@ -1988,10 +1988,10 @@ body > footer .license svg {
         padding-right: var(--vocabulary-page-edges-space);
     }
 
-    .search-index main > header:before { 
+    .search-index main > header:before {
         left: 0;
     }
-    
+
     .team-index main > header {
         padding: 0 var(--vocabulary-page-edges-space);
     }

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/css/vocabulary.css
@@ -1,8 +1,4 @@
 /*
-This is a prototype file for Vocabulary,
-that may be later ported into Vocabulary
-proper.
-
 Style rules are written with two sections
 at current, separated by an empty line.
 
@@ -38,7 +34,6 @@ EX:
     top: 0;
     left: 0;
     margin: -1000px;
-
 }
 
 .skip-to-content:focus {
@@ -48,20 +43,739 @@ EX:
 /* typography */
 
 body {
-    /* font-family: Arial;   */
+    display: grid;
+    grid-template-columns: 5% 3% 6% 6% 15% 30% 15% 6% 6% 3% 5%;
+    overflow-x: hidden;
+
     font-weight: 400;
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
 }
 
-/* still questionable as a rule */
-h2, h3 {
-    text-transform: uppercase;
+a.more {
+    padding: .4em .7em;
+
+    background: black;
+    color: white;
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 1.2em;
+    text-transform: none;
+    text-decoration: none;
+    text-shadow: none;
 }
+
 
 /* ************************* */
 
+/* temp */
+
+/* body > header {display: none;} */
+/* body > footer {display: none;} */
+
+/* components */
+
+/* post component - singular */
+
+.post header {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: baseline;
+    width: 100%;
+}
+
+.post .categories {
+    order: -1;
+
+    font-family: 'Source Sans Pro';
+}
+
+/* post component - plural */
+
+.posts {
+    text-align: center;
+}
+
+.posts > h2 {
+    margin-bottom: 2.1em;
+
+    font-family: 'Roboto Condensed';
+    /* font-size: 2.1em; */
+    font-style: normal;
+    font-weight: 700;
+    text-transform: none;
+    text-align: left;
+}
+
+.posts .post {
+    display: flex;
+    flex-wrap: wrap;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+    'title title'
+    'image teaser';
+    gap: 2em;
+    margin-bottom: 8em;
+    position: relative;
+
+    text-align: left;
+}
+
+/* .posts .post header {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: baseline;
+    width: 100%;
+} */
+
+.posts .post h2, .posts .post h3 {
+    grid-area: title;
+    width: 100%;
+    margin-top: 0.83em;
+
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 2.1em;
+    text-transform: none;
+    text-transform: initial;
+}
+
+/* .posts .post .categories {
+    order: -1;
+
+    font-family: 'Source Sans Pro';
+} */
+
+.posts .post .byline {
+    font-family: 'Source Sans Pro';
+}
+
+.posts .post .type {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: .5em .7em;
+
+    background: var(--vocabulary-brand-color-soft-turquoise);
+    border-radius: 4px;
+    font-family: 'Source Sans Pro';
+}
+
+.posts .post figure {
+    display: inline-block;
+    width: 50%;
+    grid-area: image;
+    margin: 0;
+    padding: 0;
+    flex: 1;
+}
+
+.posts .post img {
+    width: 100%;
+}
+
+.posts .post p {
+    flex: 1;
+    display: inline-block;
+    grid-area: teaser;
+    margin-top: 0;
+}
+
+.posts a.more {
+    display: inline-block;
+    margin: 0 auto;
+    margin-bottom: 4em;
+}
+
+.posts .attribution {
+    display: inline-block;
+    margin-top: 1em;
+
+    font-family: 'Source Sans Pro';
+}
+
+/* contexts - in ascending order of specificity */
+
+/* .posts .related variant context */
+
+/* <main> level context */
+
+main {
+    display: grid;
+    grid-template-columns: subgrid;
+    width: 100%;
+    margin: 0;
+    margin-bottom: 8em;
+    padding: 0;
+    grid-column: 1 / 12;
+}
+
+main > * {
+    grid-column: 5 / span 3;
+}
+
+main > header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 4em;
+    padding-top: 2em;
+    padding-bottom: 1em;
+    position: relative;
+    grid-template-columns: subgrid;
+    grid-column: 5 / span 3;
+
+    text-align: center;
+    color: #333; /* for testing */
+}
+
+main > header:before {
+    width: 100vw;
+    height: 100%;
+    position: absolute;
+    left: -33.333%;
+    top: 0;
+    z-index: -1;
+    content: '';
+
+    background: #F5F5F5;
+}
+
+main > header h1 {
+    width: 100%;
+    margin-top: .39em;
+    margin-bottom: 0;
+    grid: 0 / auto;
+
+    font-family: 'Roboto Condensed';
+    font-size: 3.56em;
+    font-style: normal;
+    font-weight: 700;
+    /* text-transform: uppercase; */
+}
+
+main > header h2 {
+    margin: 0;
+    margin-top: .2em;
+}
+
+main > header a {
+    color: var(--vocabulary-brand-color-dark-tomato);
+    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+main > header .categories {
+    order: -1;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.2em;
+    font-style: normal;
+    font-weight: 400;
+}
+
+main > header .byline {
+    display: block;
+    width: 100%;
+    margin-top: 2em;
+    margin-bottom: 2em;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.2em;
+    font-style: normal;
+    font-weight: 400;
+    font-style: italic;
+}
+
+/* if aside is present, split to two-col */
+main:has( > aside.sidebar) > div { /* was '>  *' */
+    grid-column: 2 / span 5;
+}
+
+main:has( > aside.sidebar) > article {
+    grid-column: 2 / span 5;
+}
+
+main:has( > aside.sidebar) > aside.sidebar {
+    grid-column: 7 / span 4;
+    grid-row-start: 2;
+    padding-left: 4.1em;
+}
+
+main > aside.sidebar h2 {
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 1.5em;
+}
+
+main > aside.sidebar nav {
+    margin-bottom: 3em;
+}
+
+main > aside.sidebar nav.filter-menu ul li {
+    margin-bottom: 0;
+    padding: 1em;
+}
+
+main > aside.sidebar nav.filter-menu ul li.current {
+    background: var(--vocabulary-brand-color-soft-tomato);
+    /* padding: 1em; */
+    font-weight: bold;
+}
+
+main > aside.sidebar nav.filter-menu ul li.current a {
+    --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
+}
+
+main > aside.sidebar nav ul {
+    margin: 0;
+    padding: 0;
+    
+    text-indent: none;
+    list-style: none;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+main > aside.sidebar nav ul ul {
+    margin-top: .8em;
+    margin-left: 1em;
+}
+
+main > aside.sidebar nav ul li {
+    margin-bottom: 1em;
+
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 1.1em;
+    line-height: 150%;
+}
+
+main > aside.sidebar nav ul ul li {
+    margin-bottom: .8em;
+}
+
+main > aside.sidebar nav ul ul {
+    margin-left: 1em;
+}
+
+main > aside.sidebar nav ul ul li {
+    margin-bottom: .8em;
+}
+
+main > aside.sidebar p {
+    font-size: 1em;
+}
+
+main > aside.sidebar .attention {
+    margin-top: 5em;
+    padding: 1.5em;
+
+    background: var(--vocabulary-brand-color-soft-turquoise);
+}
+
+main > aside.sidebar .attention a {
+    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+}
+
+main h2 {
+    width: 100%;
+    box-sizing: border-box;
+
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 2.1em;
+    text-transform: none;
+}
+
+main h3 {
+    box-sizing: border-box;
+    
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 1.75em;
+    text-transform: none;
+}
+
+main aside.opening {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 25%;
+    margin-bottom: 2em;
+    padding: 2em;
+    width: 100%;
+
+    background: #FEEDE9;
+}
+
+
+main aside.opening a {
+    color: var(--vocabulary-brand-color-dark-tomato);
+    --underline-background-color: #FEEDE9;
+}
+
+main aside.opening p {
+    margin :0;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.2em;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 150%;
+}
+
+main a {
+     /* better hyperlink underline typesetting inspired by Tufte CSS */
+     --underline-color: var(--vocabulary-brand-color-dark-tomato);
+     --underline-background-color: white;
+     color: var(--vocabulary-brand-color-dark-tomato);
+     text-decoration: none;
+
+     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
+     background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
+     background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
+     -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+     -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+     background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+     background-repeat: no-repeat, no-repeat, repeat-x;
+     text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
+     background-position: 0% 93%, 100% 93%, 0% 93%;
+     background-position-y: 90%, 90%, 90%;
+}
+
+main p {
+    margin-bottom: 2em;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.5em;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 150%;
+}
+
+main ul, main ol {
+    margin: 0 0 2em 1em;
+    padding: 0;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.5rem;
+    font-style: normal;
+    font-weight: 400;
+    /* line-height: 150%; */
+}
+
+main ul ul, main ol ol {
+    font-size: 1.2rem;
+}
+
+main blockquote {
+    margin: 0;
+    margin-bottom: 1.5em;
+    padding: 0;
+}
+
+/* manually include quote icon to avoid extraneous html classes */
+main blockquote p:before {
+    --icon-sprite: var(--cc-quote);
+
+    display: block;
+    content: '';
+    height: 1em;
+    width: 1em;
+
+    font-size: var(--icon-sprite-size);
+    background-color: var(--icon-sprite-color);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-image: var(--icon-sprite);
+    mask-image: var(--icon-sprite);
+    -webkit-mask-size: contain;
+    mask-size: contain;
+}
+
+main blockquote p {
+    font-family: 'Source Sans Pro';
+    font-weight: bold;
+    font-size: 1.9em;
+    line-height: 105%;
+}
+
+main figure {
+    margin: 0;
+    margin-bottom: 3em;
+    padding: 0;
+}
+
+main > article figure img, main > figure img, main > .content figure img {
+    width: 100%;
+}
+
+main figure .attribution {
+    display: block;
+    margin-top: 1em;
+
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    line-height: 150%;
+}
+
+main figure:has(iframe) {
+    grid-column: 4 / span 5;
+    float: none;
+}
+
+main aside.closing {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 25%;
+    margin-bottom: 2em;
+    padding: 2em;
+    width: 100%;
+
+    background: var(--vocabulary-brand-color-soft-turquoise);
+}
+
+main aside.closing a {
+    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+    color: var(--vocabulary-brand-color-dark-tomato);
+}
+
+main aside.closing p {
+    margin :0;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.2em;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 150%;
+}
+
+main .pub-date {
+    display: inline-block;
+    margin-bottom: 4em;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.5em;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 150%;
+}
+
+main article.tags {
+    margin-bottom: 8em;
+}
+
+main article.tags ul {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+    left: 0;
+
+    list-style: none;
+}
+
+main article.tags ul li {
+    margin-right: .5em;
+}
+
+
+main article.tags ul li:after {
+    margin-left: .1em;
+
+    content: ',';
+}
+
+main article.tags ul li:last-child:after {
+    content: '';
+}
+
+main > footer {
+    grid-column: 3 / span 7;
+}
+
+main article.posts.related {
+    grid-column: 3 / span 7;
+    padding: 2em 4em;
+    box-sizing: border-box;
+
+    background: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+main article.posts.related > h2 {
+    margin-bottom: 0.83em;
+}
+
+main article.posts.related ul {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    margin: 0 auto;
+    margin-top: 0;
+    gap: 2em;
+    box-sizing: border-box;
+    list-style: none;
+
+    font-size: initial;
+}
+
+main article.posts.related ul li {
+    margin-bottom: 3em;
+}
+
+main article.posts.related .post  {
+    margin-bottom: 0;
+}
+
+main article.posts.related .post header {
+    flex-direction: column;
+    align-items: baseline;
+}
+
+main article.posts.related .post figure {
+    display: none;
+    order: -1; 
+}
+
+main article.posts.related .post a {
+    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+main article.posts.related .post h2, main article.posts.related .post h3 {
+    font-size: 1.4em;
+}
+
+main article.posts.related .post p {
+    display: none;
+}
+
+main nav.pagination {
+    margin: 0 auto;
+}
+
+main nav.pagination ol {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    
+    text-indent: none;
+    font-size: 1em;
+    list-style: none;
+}
+
+main nav.pagination ol li {
+    margin: 0 .5em;
+
+    line-height: 250%;
+}
+
+main nav.pagination ol li a {
+    padding: .4em .7em;
+
+    background: #F5F5F5;
+    --underline-background-color: #F5F5F5;
+    color: black;
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 1.2em;
+    text-transform: none;
+    text-decoration: none;
+}
+
+main nav.pagination ol li.current a {
+    background: black;
+    --underline-background-color: black;
+    color: white;
+}
+
+main .attribution-list {
+    grid-column: 3 / span 7;
+    box-sizing: border-box;
+    position: relative;
+    padding: 4em; 
+
+    background: var(--vocabulary-neutral-color-lighter-gray);
+    text-align: left;
+}
+
+main .attribution-list h2 {
+    margin: 0;
+}
+
+main .attribution-list button.expand-attribution {
+    position: absolute;
+    top: 4.5em;
+    right: 4em;
+    padding: .5em;
+
+    cursor: pointer;
+    border: 1px solid black;
+    border-radius: 3px;
+    font-family: 'Source Sans Pro';
+}
+
+main .attribution-list button.expand-attribution.selected {
+    background: black;
+    color: white;
+}
+
+main .attribution-list ul {
+    display: none;
+}
+
+main .attribution-list ul.expand {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    margin: 0;
+    margin-top: 2em;
+    padding: 0;
+    gap: 2em;
+
+    font-size: 1em;
+    list-style: none;
+}
+
+main .attribution-list article {
+    margin-bottom: 1em;
+}
+
+main .attribution-list article a {
+    --underline-background-color: var(--vocabulary-brand-color-grey);
+}
+
+main .attribution-list article figure {
+    display: flex;
+    gap: 1em;
+    margin-top: 1em;
+}
+
+main .attribution-list article img {
+    object-fit: cover;
+    width: 4em;
+    height: 4em;
+}
+
+main .attribution-list article figure .attribution {
+    margin-top: 0;
+}
+
+/* <body> general page-level context */
+
+/* body-level context */
+
+/* global header component */
 body > header {
+    grid-column: 1 / 12;
     display: flex;
     flex-wrap: wrap;
     position: relative;
@@ -69,32 +783,31 @@ body > header {
     /* padding: 0 var(--vocabulary-page-edges-space); */
 }
 
-.masthead {
+body > header .masthead {
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
     align-items: baseline;
     position: relative;
-
     width: 100%;
     /* padding-top: 3%; */
     padding-top: 40px;
     margin: 0 var(--vocabulary-page-edges-space);
 }
 
-.masthead h1 {
+body > header .masthead h1 {
     margin: 0;
 }
 
 /* allows the child identity-logo element to have a focus state */
-.identity-logo-wrapper {
+body > header .identity-logo-wrapper {
     height: 50px;
     width: 191px;
     display: block;
     position: absolute;
 }
 
-.masthead .identity-logo {
+body > header .masthead .identity-logo {
     display: inline-block;
     text-indent: -1000px;
     vertical-align: bottom;
@@ -104,17 +817,17 @@ body > header {
 
     /* allows for color manipulation of svg */
     background-color: black;
-    -webkit-mask-image: url('./../svg/cc/logos/cc/logomark.svg');
-    mask-image: url('./../svg/cc/logos/cc/logomark.svg');
+    -webkit-mask-image: url('../svg/cc/logos/cc/logomark.svg');
+    mask-image: url('../svg/cc/logos/cc/logomark.svg');
     -webkit-mask-repeat: no-repeat;
     mask-repeat: no-repeat;
     cursor: pointer;
 
     /* standard pattern for setting logo in lieu of background color manipulation */
-    /* background: url('../../svg/cc/logos/cc/logomark.svg') left top no-repeat; */
+    /* background: url('../svg/cc/logos/cc/logomark.svg') left top no-repeat; */
 }
 
-.masthead .identity-logo:hover {
+body > header .masthead .identity-logo:hover {
     background-color: var(--vocabulary-neutral-color-dark-gray);
 }
 
@@ -139,15 +852,15 @@ body > header {
 } */
 
 /* style product identity typesetting */
-.masthead .identity-logo.product {
+body > header .masthead .identity-logo.product {
     width: initial;
     position: relative;
-    text-indent: 42px;
     padding-top: 7px;
     box-sizing: border-box;
 
     text-decoration: none;
-    font-family: "CC Accidenz Commons";
+    text-indent: 42px;
+    font-family: 'CC Accidenz Commons';
     font-weight: normal;
     text-transform: lowercase;
     letter-spacing: -1px;
@@ -159,7 +872,7 @@ body > header {
 }
 
 /* style product identity mini-cc-logo */
-.masthead .identity-logo.product:before {
+body > header .masthead .identity-logo.product:before {
     position: absolute;
     width: 40px;
     height: 40px;
@@ -168,45 +881,8 @@ body > header {
     top: .176em;
 
     background-color: black;
-    -webkit-mask-image: url('./../svg/cc/logos/cc/lettermark.svg');
-    mask-image: url('./../svg/cc/logos/cc/lettermark.svg');
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    cursor: pointer;
-}
-
-/* style product identity typesetting */
-.masthead .identity-logo.product {
-    width: initial;
-    position: relative;
-    text-indent: 42px;
-    padding-top: 7px;
-    box-sizing: border-box;
-
-    text-decoration: none;
-    font-family: "CC Accidenz Commons";
-    font-weight: normal;
-    text-transform: lowercase;
-    letter-spacing: -1px;
-    line-height: 1em;
-    -webkit-mask-image: none;
-    mask-image: none;
-    background: none;
-    color: black;
-}
-
-/* style product identity mini-cc-logo */
-.masthead .identity-logo.product:before {
-    position: absolute;
-    width: 40px;
-    height: 40px;
-    content: '';
-    left: 0;
-    top: .176em;
-
-    background-color: black;
-    -webkit-mask-image: url('./../svg/cc/logos/cc/lettermark.svg');
-    mask-image: url('./../svg/cc/logos/cc/lettermark.svg');
+    -webkit-mask-image: url('../svg/cc/logos/cc/lettermark.svg');
+    mask-image: url('../svg/cc/logos/cc/lettermark.svg');
     -webkit-mask-repeat: no-repeat;
     mask-repeat: no-repeat;
     cursor: pointer;
@@ -218,7 +894,7 @@ body > header {
 
 } */
 
-.masthead .primary-menu ul {
+body > header .masthead .primary-menu ul {
     display: flex;
     justify-content: space-around;
     width: 100%;
@@ -228,14 +904,14 @@ body > header {
     list-style: none;
 }
 
-.masthead .primary-menu ul li {
+body > header .masthead .primary-menu ul li {
     display: flex;
     align-items: center;
     margin-top: 5px;
     margin-left: 20px;
 }
 
-.masthead .primary-menu ul li a {
+body > header .masthead .primary-menu ul li a {
     text-decoration: none;
     text-transform: uppercase;
     font-family: var(--vocabulary-brand-typeset-nav-family);
@@ -245,11 +921,11 @@ body > header {
     color: var(--vocabulary-brand-typeset-nav-color);
 }
 
-.masthead .primary-menu ul li a:hover {
+body > header .masthead .primary-menu ul li a:hover {
     color: black;
 }
 
-.masthead .primary-menu ul li a.attention {
+body > header .masthead .primary-menu ul li a.attention {
     display: inline-block;
     padding: 0.5em;
 
@@ -258,24 +934,24 @@ body > header {
     border-radius: 4px;
 }
 
-button.expand-menu {
+body > header button.expand-menu {
     display: none;
 }
 
-.ancilliary-menu {
+body > header .ancillary-menu {
     position: absolute;
     top: 0;
     /* right: var(--vocabulary-page-edges-space); */
     right: 0;
 
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 600;
     font-size: .8em;
     /* font-size: 1em; */
 }
 
-.ancilliary-menu ul {
+body > header .ancillary-menu ul {
     display: flex;
     margin: 0;
     padding: 0;
@@ -283,35 +959,34 @@ button.expand-menu {
     list-style: none;
 }
 
-.ancilliary-menu ul li {
+body > header .ancillary-menu ul li {
     margin-left: 10px;
 }
-.ancilliary-menu ul li a {
+body > header .ancillary-menu ul li a {
     /* generalize this */
     display: inline-block;
 }
 
-.ancilliary-menu ul li a,
-.ancilliary-menu ul li button {
+body > header .ancillary-menu ul li a,
+.ancillary-menu ul li button {
     margin-top: 10px;
 }
 
-.ancilliary-menu ul li button:hover {
+body > header .ancillary-menu ul li button:hover {
     cursor: pointer;
 }
 
-.ancilliary-menu button.locale {
+body > header .ancillary-menu button.locale {
     display: inline-flex;
     align-items: center;
     padding: 6px 10px;
-
 
     background:  var(--vocabulary-neutral-color-lighter-gray);
     border: none;
     border-radius: 3px;
 }
 
-.ancilliary-menu button.locale.icon-attach:before {
+body > header .ancillary-menu button.locale.icon-attach:before {
     --icon-sprite: var(--fa-globe);
     --icon-sprite-size: .8em;
 
@@ -320,7 +995,7 @@ button.expand-menu {
     opacity: .3;
 }
 
-.ancilliary-menu a.donate {
+body > header .ancillary-menu a.donate {
     display: inline-flex;
     align-items: center;
     padding: 6px 10px;
@@ -331,7 +1006,7 @@ button.expand-menu {
     border-radius: 3px;
 }
 
-.ancilliary-menu a.donate.icon-attach:before {
+.ancillary-menu a.donate.icon-attach:before {
     --icon-sprite: var(--fa-heart);
     --icon-sprite-color: var(--vocabulary-brand-color-dark-tomato);
      --icon-sprite-size: .8em;
@@ -339,7 +1014,7 @@ button.expand-menu {
     margin-right: .8em;
 }
 
-.ancilliary-menu a.search {
+body > header .ancillary-menu a.search {
     display: inline-flex;
     align-items: center;
     padding: 6px 10px;
@@ -352,14 +1027,14 @@ button.expand-menu {
     border-radius: 3px;
 }
 
-.ancilliary-menu a.search.icon-attach:before {
+body > header .ancillary-menu a.search.icon-attach:before {
     --icon-sprite: var(--fa-search);
      --icon-sprite-size: .8em;
 
     margin-right: .8em;
 }
 
-.ancilliary-menu button.explore {
+body > header .ancillary-menu button.explore {
     margin-top: 0;
     padding-top: 16px;
     padding-bottom: 6px;
@@ -373,7 +1048,7 @@ button.expand-menu {
     border-bottom-left-radius: 5px;
 }
 
-.explore-panel {
+body > header .explore-panel {
     order: -1;
     display: flex;
     justify-content: space-between;
@@ -382,15 +1057,21 @@ button.expand-menu {
 
     background: black;
     color: white;
+    display: none;
 }
 
-.explore-panel aside {
+.explore-panel.expand {
+    display: inherit;
+
+    transition: display 2s ease-in-out;
+}
+
+body > header .explore-panel aside {
     margin-right: 20px;
 }
 
-.explore-panel aside .identity-logo {
+body > header .explore-panel aside .identity-logo {
     display: inline-block;
-    text-indent: -1000px;
     vertical-align: bottom;
     height: 50px;
     width: 191px;
@@ -398,76 +1079,66 @@ button.expand-menu {
 
     /* allows for color manipulation of svg */
     background-color: white;
-    -webkit-mask-image: url('./../svg/cc/logos/cc/logomark.svg');
-    mask-image: url('./../svg/cc/logos/cc/logomark.svg');
+    -webkit-mask-image: url('../svg/cc/logos/cc/logomark.svg');
+    mask-image: url('../svg/cc/logos/cc/logomark.svg');
     -webkit-mask-repeat: no-repeat;
     mask-repeat: no-repeat;
     cursor: pointer;
+    text-indent: -1000px;
 
     /* standard pattern for setting logo in lieu of background color manipulation */
-    /* background: url('../../svg/cc/logos/cc/logomark.svg') left top no-repeat; */
-
+    /* background: url('../svg/cc/logos/cc/logomark.svg') left top no-repeat; */
 }
 
-.explore-panel aside h2 {
+body > header .explore-panel aside h2 {
     font-family: 'Roboto Condensed';
     font-style: normal;
     font-weight: 700;
-
 }
 
-.explore-panel aside p {
+body > header .explore-panel aside p {
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
 }
 
-.explore-panel .explore-menu {
+body > header .explore-panel .explore-menu {
     width: 100%;
 
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
-
 }
 
-.explore-panel .explore-menu ul {
+body > header .explore-panel .explore-menu ul {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     gap: 20px;
-
     margin: 0;
     padding: 0;
 
     list-style: none;
-
 }
 
-.explore-panel nav ul li a {
+body > header .explore-panel nav ul li a {
     display: block;
 
     color: var(--vocabulary-brand-color-turquoise);
     text-decoration: none;
     font-weight: 700;
     /* margin-bottom: .8em; */
-
-
 }
 
-.explore-panel nav ul li p {
+body > header .explore-panel nav ul li p {
     font-weight: inherit;
     line-height: 1.5;
 }
 
-body {
-    overflow-x: hidden;
-}
-
-/* top page banner */
 body > article.attention {
-    background: var(--vocabulary-brand-color-soft-green);
-    padding: 1em 5%;
+    grid-column: 1 / span 11;
+    padding: 1em var(--vocabulary-page-edges-space);
 
+    background: var(--vocabulary-brand-color-soft-green);
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
@@ -478,10 +1149,9 @@ body > article.attention {
 }
 
 /* bottom page banner */
-body > article.attention:nth-of-type(2) {
-    /* grid-column: span 3; */
+/* body > article.attention:nth-of-type(2) {
     background: var(--vocabulary-brand-color-soft-gold);
-}
+} */
 
 body > article.attention a {
     color: var(--vocabulary-brand-color-dark-green);
@@ -524,849 +1194,368 @@ body > article.attention.low-importance a:before, body > article.attention.mediu
     mask-image: var(--icon-sprite);
     -webkit-mask-size: contain;
     mask-size: contain;
-  }
+}
 
-  body > .attention.low-importance {
+body > .attention.low-importance {
     background: var(--vocabulary-brand-color-soft-green);
     border-bottom: 8px solid var(--vocabulary-brand-color-green);
-  }
+}
 
-  body > .attention.medium-importance {
+body > .attention.medium-importance {
     background: var(--vocabulary-brand-color-soft-gold);
     border-bottom: 8px solid var(--vocabulary-brand-color-gold);
-  }
+}
 
-  body > .attention.high-importance {
+body > .attention.high-importance {
     background: var(--vocabulary-brand-color-soft-tomato);
     border-bottom: 8px solid var(--vocabulary-brand-color-tomato);
-  }
+}
 
-.default-page main {
-    width: 90%;
-    box-sizing: border-box;
+/* global footer component */
+body > footer {
+    grid-column: 1 / 12;
     display: grid;
-    gap: 0 4.1em;
-    grid-template-columns: 1fr 1.22fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-template-areas:
-    'header header header'
-    'content content sidebar';
-    padding: 0;
+    'logo nav nav nav'
+    'contact subscribe subscribe donate'
+    'contact license license donate';
+    gap: 40px;
+    padding: 40px var(--vocabulary-page-edges-space);
 
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    color: white;
+    background: black;
 }
 
-.default-page main > header:before {
-    left: -5.5%;
-}
-
-.default-page main > header {
-    display: block;
-    grid-area: header;
-    padding: 3.7em 0;
-
-    justify-content: left;
-    text-align: left;
-}
-
-.default-page main > header h1 {
-    margin: 0;
-}
-
-.default-page main > header p {
-    /* margin-top: 0;
-    margin-bottom: 0; */
-    margin-bottom: .3em;
-}
-
-.default-page main > aside {
-    grid-area: sidebar;
-    /* width: 100%; */
-}
-
-.default-page main > aside h2 {
+body > footer h2 {
     font-family: 'Roboto Condensed';
     font-style: normal;
     font-weight: 700;
-    font-size: 1.5em;
+    font-size: 1.25em;
 }
 
-.default-page main > aside a {
-     /* better hyperlink underline typesetting inspired by Tufte CSS */
-     --underline-color: var(--vocabulary-brand-color-dark-tomato);
-     --underline-background-color: white;
-     color: var(--vocabulary-brand-color-dark-tomato);
-     text-decoration: none;
-
-     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
-     background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
-     background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
-     -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     background-repeat: no-repeat, no-repeat, repeat-x;
-     text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
-     background-position: 0% 93%, 100% 93%, 0% 93%;
-     /* background-position-y: 87%, 87%, 87%; */
+body > footer a {
+    color: var(--vocabulary-brand-color-turquoise);
+    text-decoration: none;
 }
 
-.default-page main > aside nav {
-    margin-bottom: 3em;
+body > footer p {
+    line-height: 1.5;
 }
 
-.default-page main > aside nav ul {
+/* needs to be moved to be broader in general specificity scope */
+body > footer p a {
+    /* better hyperlink underline typesetting inspired by Tufte CSS */
+    --underline-color: var(--vocabulary-brand-color-turquoise);
+    --underline-background-color: black;
+    color: var(--vocabulary-brand-color-turquoise);
+    /* text-decoration: none; */
+
+    /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
+    background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
+    background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
+    -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+    -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+    background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+    background-repeat: no-repeat, no-repeat, repeat-x;
+    text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
+    background-position: 0% 93%, 100% 93%, 0% 93%;
+    /* background-position-y: 87%, 87%, 87%; */
+
+}
+
+body > footer .identity-logo {
+    grid-area: logo;
+    display: inline-block;
+    text-indent: -1000px;
+    vertical-align: bottom;
+    height: 50px;
+    width: 191px;
+
+
+    /* allows for color manipulation of svg */
+    background-color: white;
+    -webkit-mask-image: url('../svg/cc/logos/cc/logomark.svg');
+    mask-image: url('../svg/cc/logos/cc/logomark.svg');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    cursor: pointer;
+
+    /* standard pattern for setting logo in lieu of background color manipulation */
+    /* background: url('../svg/cc/logos/cc/logomark.svg') left top no-repeat; */
+}
+
+body > footer .identity-logo:hover {
+    background-color: var(--vocabulary-brand-color-turquoise);
+}
+
+body > footer .footer-menu {
+    grid-area: nav;
+
+    font-size: 1.3em;
+    font-weight: 700;
+}
+
+body > footer .footer-menu ul {
+    display: flex;
+    justify-content: space-between;
     margin: 0;
     padding: 0;
-    text-indent: none;
 
     list-style: none;
-    font-size: 1rem;
-    font-weight: 700;
 }
 
-.default-page main > aside nav ul ul {
-    margin-top: .8em;
-    margin-left: 1em;
+body > footer .footer-menu ul li a {
+    text-decoration: none;
+    color: var(--vocabulary-brand-color-turquoise);
 }
 
-.default-page main > aside nav ul li {
-    margin-bottom: 1em;
-
-    font-family: 'Source Sans Pro';
-    font-style: normal;
-    font-weight: 400;
-    font-size: 1.1em;
-    line-height: 150%;
+body > footer .contact {
+    grid-area: contact;
 }
 
-.default-page main > aside nav ul ul li {
-    margin-bottom: .8em;
-}
-
-.default-page main > aside nav ul ul {
-    margin-left: 1em;
-}
-
-.default-page main > aside nav ul ul li {
-    margin-bottom: .8em;
-}
-
-.default-page main > aside nav.filter-menu h2 {
-    /* margin-left: .5em; */
-}
-
-.default-page main > aside nav.filter-menu ul li {
-    margin-bottom: 0;
-    padding: 1em;
-}
-
-.default-page main > aside nav.filter-menu ul li.current {
-    background: var(--vocabulary-brand-color-soft-tomato);
-    /* padding: 1em; */
-    font-weight: bold;
-}
-
-.default-page main > aside nav.filter-menu ul li.current a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
-}
-
-.default-page main > aside h2:nth-child(1) {
-    margin-top: 0;
-}
-
-.default-page main > aside .attention {
-    background: var(--vocabulary-brand-color-soft-turquoise);
-    margin-top: 5em;
-    padding: 1.5em;
-}
-
-.default-page main > aside .attention p {
-    font-size: 1em;
-}
-
-.default-page main > aside .attention a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
-
-}
-
-.default-page main > .content {
-    grid-area: content;
-    /* width: 100%; */
-}
-
-/* .default-page main > .content h2 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 2.1em;
-    text-transform: none;
-}
-
-.default-page main > .content h3 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.75em;
-    text-transform: none;
-} */
-
-.default-page main > .content p:nth-child(1) {
-    margin-top: 0;
-}
-
-/*
-.default-page main > .content {
-    grid-column: span 3;
-    width: 100%;
-}
-
-.default-page main:has(aside) {
-    gap: 0;
-}
-
-.default-page main:has(aside) > .content {
-    grid-area: content;
-} */
-
-.blog-index-alt main {
-    width: 100%;
-    padding: 0;
-}
-
-.blog-index-alt main > header:before {
-    left: initial;
-}
-
-.blog-index-alt main > header {
-    padding-top: 1em;
-    /* padding-bottom: 5em; */
-    margin-bottom: 0;
-}
-
-.blog-index-alt main > header h1 {
-    margin-top: 0.67em;
-    margin-bottom: 0;
-}
-
-.blog-index-alt main .authored-posts {
-    margin-top: 8em;
-    padding: 0 4em;
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-    gap: 3em;
-    box-sizing: border-box;
-}
-
-.blog-index-alt main .authored-posts.highlight {
-    /* margin-top: -10em; */
-    margin-top: 0;
-    padding: 0 4em;
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-    gap: 3em;
-    box-sizing: border-box;
-
-    background: var(--vocabulary-neutral-color-lighter-gray);
-
-}
-
-.blog-index-alt main .authored-posts article {
+body > footer .contact .social-menu ul {
     display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    position: relative;
-}
-
-.blog-index-alt main .authored-posts.highlight article a {
-    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-
-}
-
-.blog-index-alt main .authored-posts.highlight article:nth-child(1) {
-    grid-column: span 3;
-    padding: 2em;
-
-    background: var(--vocabulary-brand-color-soft-tomato);
-    background: white;
-    border: 16px solid white;
-}
-
-
-.blog-index-alt main .authored-posts.highlight article:nth-child(1) a {
-    --underline-background-color: white;
-    /* background: white; */
-}
-
-
-.blog-index-alt main .authored-posts article header {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-
-.blog-index-alt main .authored-posts article h2 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.5em;
-    text-transform: none;
-    text-transform: initial;
-}
-
-.blog-index-alt main .authored-posts.highlight article:nth-child(1) h2 {
-    font-size: 2.1em;
-}
-
-
-.blog-index-alt main .authored-posts article header .categories {
-    order: -1;
-}
-
-.blog-index-alt main .authored-posts article figure {
-    width: 100%;
     margin: 0;
-}
-
-.blog-index-alt main .authored-posts article figure img {
-    /* position: absolute;
-    top: 2em;
-    left: 0;
-    z-index: -1; */
-    width: 100%;
-
-}
-
-
-.blog-index-alt main .authored-posts article p {
-    display: none;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-.blog-post main h2 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 2.1em;
-    text-transform: none;
-}
-
-.authored-posts article h2 {
-    grid-area: title;
-    width: 100%;
-}
-
-
-/* .blog-post main h3 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.75em;
-    text-transform: none;
-} */
-
-.blog-post figure {
-    width: 120%;
-    margin-left: -10%;
-}
-
-.blog-post main .closing {
-    display: inline-block;
-    /* position: absolute;
-    left: -25%;
-    bottom: -10%; */
-    box-sizing: border-box;
-    /* min-height: 150px; */
-    width: 25%;
-    /* float: left; */
-    /* margin: 2em; */
-    margin-bottom: 2em;
-    padding: 2em;
-    width: 100%;
-
-    background: var(--vocabulary-brand-color-soft-turquoise);
-    /* color: white; */
-    /* color: var(--vocabulary-brand-color-dark-tomato); */
-
-  }
-
-  .blog-post main .closing a {
-    color: var(--vocabulary-brand-color-dark-tomato);
-    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
-  }
-
-  .blog-post main .closing p {
-    margin :0;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.2em;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%;
-  }
-
-
-
-
-.blog-index main {
-    width: 100%;
     padding: 0;
-}
-
-.blog-index main > header:before {
-    left: initial;
-    /* background: white; */
-}
-
-.blog-index main > header {
-    padding-top: 1em;
-    /* padding-bottom: 5em; */
-    margin-bottom: 0;
-
-}
-
-.blog-index main > header h1 {
-    margin-top: 0.67em;
-    margin-bottom: 0;
-}
-
-.blog-index main .authored-posts {
-    /* display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    margin-top: 8em;
-    padding: 0 4em;
-    gap: 3em;
-    box-sizing: border-box; */
-    width: 60%;
-    margin: 0 auto;
-    margin-top: 8em;
-}
-
-.blog-index main .authored-posts.highlight {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-    margin-top: 8em;
-    padding: 0 4em;
-    gap: 2em;
-    box-sizing: border-box;
-
-    width:100%;
-    margin: 0 auto;
-    margin-top: 0;
-    /* padding: 0; */
-
-    background: var(--vocabulary-neutral-color-lighter-gray);
-}
-
-.blog-index main .authored-posts.highlight:nth-of-type(1) article {
-    margin-bottom: 6em;
-}
-
-.blog-index main .authored-posts.highlight article.story {
-    grid-column: span 3;
-}
-
-.blog-index main .authored-posts.highlight article figure {
-    order: -1;
-
-}
-
-.blog-index main .authored-posts.highlight article a {
-    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-}
-
-.blog-index main .authored-posts.highlight article h2, .blog-index main .authored-posts.highlight article h3 {
-    font-size: 1.4em;
-}
-
-.blog-index main .authored-posts.highlight:nth-of-type(1) > article:nth-child(1) {
-    grid-column: span 12;
-    margin-bottom: 1em;
-    padding: 4em;
-
-    background: var(--vocabulary-brand-color-soft-tomato);
-    /* background: var(--vocabulary-brand-color-soft-turquoise); */
-    background: white;
-}
-
-.blog-index main .authored-posts.highlight:nth-of-type(1) article:nth-child(1) a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
-    /* --underline-background-color: var(--vocabulary-brand-color-soft-turquoise); */
-    --underline-background-color: white;
-}
-
-.blog-index main .authored-posts.highlight:nth-of-type(1) article:nth-child(1) h2 {
-    font-size: 2.1em;
-}
-
-.blog-index main .authored-posts.highlight:nth-of-type(1) article:nth-child(1) figure {
-    order: initial;
-}
-
-
-.blog-index main .authored-posts.highlight article.story:nth-child(n+6) {
-    grid-column: span 4;
-}
-
-/* .blog-index main .authored-posts.highlight article:nth-child(2) {
-    padding-left: 4em;
-}
-
- .blog-index main .authored-posts.highlight article:nth-child(4) {
-    margin-right: 4em;
- } */
-
-
-
-
- .blog-index main .authored-posts.highlight:nth-of-type(2) {
     margin-top: 3em;
 
-    background: white;
- }
-
-
- .blog-index main .authored-posts.highlight:nth-of-type(2) article {
-    grid-column: span 4;
-
- }
-
- .blog-index main .authored-posts.highlight:nth-of-type(2) h2 {
-    grid-column: span 12;
-    margin-bottom: 1em;
-
-    text-align: center;
- }
-
- .blog-index main .authored-posts.highlight:nth-of-type(2) article a {
-    --underline-background-color: white;
- }
-
- .blog-index main footer {
-    margin: 0 5%;
-
-    text-align: center;
+    list-style: none;
 }
 
-.blog-index footer a.more {
-    display: inline-block;
-    margin: 0 auto;
-    margin-bottom: 4em;
-
+body > footer .contact .social-menu ul li {
+    margin-right: 1.5em;
 }
 
-.blog-index .attribution-list {
+body > footer .social-menu li a {
+    --icon-sprite-color: white;
+    --icon-sprite-size: 1.9em;
+}
+
+body > footer .subscribe {
+    grid-area: subscribe;
+}
+
+body > footer .subscribe form {
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+}
+
+body > footer .subscribe form input {
+    display: inline-flex;
     position: relative;
-    padding: 4em;
-    gap: 0;
+    justify-content: flex-start;
+    align-items: center;
+    vertical-align: top;
+    box-sizing: border-box;
 
-
-    background:  var(--vocabulary-brand-color-soft-turquoise);
-    background: var(--vocabulary-brand-color-tomato);
-    background: var(--vocabulary-brand-color-soft-tomato);
-    background: var(--vocabulary-neutral-color-lighter-gray);
-    /* color: white; */
-    text-align: left;
+    -webkit-appearance: none;
+    background-color: transparent;
+    color: rgb(118, 118, 118);
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 1em;
+    font-weight: 600;
+    line-height: 1.3;
+    border: 2px solid rgb(118, 118, 118);;
+    /* border-radius: 4px; */
+    box-shadow: none;
 }
 
-.blog-index .attribution-list h2 {
-    margin: 0;
-}
-
-.blog-index .attribution-list button.expand-attribution {
-    position: absolute;
-    top: 4.5em;
-    right: 4em;
-
-    cursor: pointer;
-    border: 1px solid black;
-    border-radius: 3px;
+body > footer .subscribe form input.input {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
     padding: .5em;
-    font-family: "Source Sans Pro";
+    width: 100%;
 }
 
-.blog-index .attribution-list button.expand-attribution.selected {
-    background: black;
+body > footer .subscribe form input.input:focus {
     color: white;
 }
 
-.blog-index .attribution-list ul {
-    display: none;
+body > footer .subscribe form input.button {
+    justify-content: center;
+    padding: 1.1em;
+
+    cursor: pointer;
+    font-family: 'Roboto Condensed', sans-serif;
+    font-size: 1.125rem;
+    text-align: center;
+    text-transform: uppercase;
+    font-weight: 600;
+    line-height: 0;
+    white-space: nowrap;
+    background-color: rgb(118, 118, 118);
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    color: rgb(255, 255, 255);
 }
 
-.blog-index .attribution-list ul.expand {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    margin: 0;
-    margin-top: 2em;
-    padding: 0;
-    gap: 2em;
+body > footer .donate {
+    grid-area: donate;
+}
 
-    font-size: 1em;
+body > footer .donate a.donate {
+    display: inline-flex;
+    align-items: center;
+    padding: 1rem 1.5rem;
+
+    text-transform: uppercase;
+    font-family: 'Roboto Condensed';
+    font-size: 1.5em;
+    line-height: 1em;
+    font-style: normal;
+    font-weight: 700;
+    border: none;
+    border-radius: 4px;
+    color: black;
+    background: var(--vocabulary-brand-color-gold);
+}
+
+body > footer .donate a.donate:hover {
+    cursor: pointer;
+    background-color: rgb(248, 204, 44);
+}
+
+/* set the icon settings */
+body > footer .donate a.donate.icon-attach:before {
+    /* --icon-sprite: var(--cc-heart-filled); */
+    --icon-sprite-color: black;
+    --icon-sprite-size: 1.2em;
+
+    margin-right: .3em;
+}
+
+body > footer .license {
+    grid-area: license;
+}
+
+body > footer .license img path {
+    fill: white;
+    /* width: 1.2em; */
+}
+
+body > footer .license svg {
+    display: inline;
+    width: 1.9em;
+    height: 1.9em;
+    margin-right: .3em;
+}
+
+/* archive-page context */
+
+/* blog-index context */
+
+.blog-index main > header {
+    margin-bottom: 0;
+}
+
+.blog-index main .posts {
+    grid-column: 2 / span 9;
+}
+
+.blog-index main .posts h2 {
+    text-align: center;
+}
+
+.blog-index main .posts ul {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    margin-top: 8em;
+    /* padding: 0 4em; */
+    gap: 2em;
+    box-sizing: border-box;
+    width:100%;
+    margin: 0 auto;
+    margin-top: 0;
+
+    font-size: 1rem;
     list-style: none;
 }
 
-.blog-index .attribution-list article {
-    margin-bottom: 1em;
-}
+.blog-index main .posts ul li {
+    grid-column: span 4;
+ }
 
-.blog-index .attribution-list article a {
-    /* --underline-background-color: var(--vocabulary-brand-color-tomato); */
-    /* color: white; */
-
-    --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
-
-
-}
-
-.blog-index .attribution-list article figure {
-    display: flex;
-    gap: 1em;
-    margin-top: 1em;
-}
-
-.blog-index .attribution-list article img {
-    object-fit: cover;
-    width: 4em;
-    height: 4em;
-}
-
-.blog-index .attribution-list article figure .attribution {
-    margin-top: 0;
-}
-
-
-
-
-
-.blog-index-alt2 main {
-    width: 100%;
-    padding: 0;
-}
-
-.blog-index-alt2 main > header:before {
-    left: initial;
-    background: white;
-}
-
-.blog-index-alt2 main > header {
-    padding-top: 1em;
-    /* padding-bottom: 5em; */
-    margin-bottom: 0;
-
-}
-
-.blog-index-alt2 main > header h1 {
-    margin-top: 0.67em;
-    margin-bottom: 0;
-}
-
-.blog-index-alt2 main .authored-posts {
-    width: 60%;
-    /* display: grid;
-    grid-template-columns: 1fr 1fr 1fr; */
-    margin: 8em auto 0 auto;
-    /* padding-top: 8em; */
-    /* padding: 0 4em;
-    gap: 3em;
-    box-sizing: border-box; */
-    position: relative;
-
-}
-
-
-.blog-index-alt2 main .authored-posts.highlight {
-    width: 100%;
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 3em 2em;
-    margin: 0 auto 8em auto;
-    padding: 4em;
-    padding-top: 3em;
-    box-sizing: border-box;
-
-    background: var(--vocabulary-neutral-color-lighter-gray);
-    background: white;
-}
-
-.blog-index-alt2 main .authored-posts.highlight:before {
-    display: block;
-    content: '';
-    height: calc(100% + 8em);
-    width: 100vw;
-    position: absolute;
-    top: 0;
-    left: -5.5%;
-    z-index: -1;
-
-    background: var(--vocabulary-neutral-color-lighter-gray);
-    background: white;
-
-}
-
-/* .blog-index-alt2 main .authored-posts.highlight:after {
-    display: block;
-    content: '';
-    height: 4em;
-} */
-
-.blog-index-alt2 main .authored-posts.highlight article {
-    position: relative;
-    gap: initial;
-    margin-bottom: 0;
-}
-
-.blog-index-alt2 main .authored-posts.highlight article h2 {
-    font-size: 1.3em;
-}
-
-.blog-index-alt2 main .authored-posts.highlight article .categories {
-    /* position: absolute;
-    top: -2.5em;
-    left: 0; */
-    display: block;
-    width: 100%;
-    order: 1;
-    margin-top: 1em;
-}
-
-/* .blog-index-alt2 main .authored-posts.highlight article .byline {
-    order: 2;
-} */
-
-.blog-index-alt2 main .authored-posts.highlight article figure {
-    order: -2;
-}
-
-.blog-index-alt2 main .authored-posts.highlight article:nth-child(1) {
-    display: grid;
-    grid-template-areas: 'img header'
-                        'img teaser';
-    grid-column: span 3;
-    gap: 2em;
-    margin-bottom: 1em;
-    position: relative;
-
-    /* background: var(--vocabulary-brand-color-soft-tomato); */
-    /* padding: 4em; */
-}
-
-.blog-index-alt2 main .authored-posts.highlight article:nth-child(1) header {
-    grid-area: header;
-}
-
-.blog-index-alt2 main .authored-posts.highlight article a {
-    /* --underline-background-color: var(--vocabulary-brand-color-soft-tomato); */
-    /* --underline-background-color: var(--vocabulary-neutral-color-lighter-gray); */
-
-}
-
-.blog-index-alt2 main .authored-posts.highlight article:nth-child(1) h2 {
-    /* font-size: 1.8em; */
-}
-
-.blog-index-alt2 main .authored-posts.highlight article:nth-child(1) figure {
-    grid-area: img;
-    width: 100%;
-    margin-top: 1.5em;
-
-}
-
-.blog-index-alt2 main .authored-posts.highlight article:nth-child(1) p {
-    grid-area: teaser;
-
-    font-size: 1.2em;
-
-}
-
-.blog-index-alt2 main .authored-posts.highlight article:nth-child(1) .categories {
-    /* position: absolute;
-    top: -1.5em;
-    left: 0; */
-    /* order: 1; */
-
-    /* display: inline-block;
-    width: initial;
-    position: absolute;
-    bottom: -1em;
-    right: 0; */
-
-}
-
-
-
-/* .program-page main p {
-    grid-column: span 3;
-} */
-
-.program-index header h1 {
-    margin-bottom: 0;
-}
-
-.program-index header h2 {
-    margin-top: .25em;
-
+ .blog-index main .posts ul li h3 {
     font-size: 1.5em;
 }
 
-/* .program-page header p {
-    margin-top: 0;
-} */
-
-.program-index main > article {
-    width: 140%;
-    margin-left: -20%;
-
-
+.blog-index main .posts .post figure {
+    order: -1;
 }
 
-/* .program-page main > article h2 {
-    text-transform: uppercase;
-} */
 
-.program-index main > article.projects {
-    margin-bottom: 8em;
+/* targets the featured posts section */
+.blog-index main .posts.featured {
+    grid-column: 1 / span 11;
+    margin-bottom: 3em;
+
+    background: var(--vocabulary-neutral-color-lighter-gray);
 }
 
-.program-index main > article.projects ul {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 2em;
+.blog-index main .posts.featured h2 {
+    visibility: hidden;
+    height: 0;
     margin: 0;
     padding: 0;
-
-    font-size: 1em;
-    list-style: none;
 }
 
-.program-index main > article.projects article {
-    padding: 2em;
-
-    background: var(--vocabulary-brand-color-soft-turquoise);
-    border-top: 3px solid black;
+.blog-index main .posts.featured .post h3 {
+    font-size: 1.4em;
 }
 
-.program-index main > article.projects article a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+.blog-index main .posts.featured ul li:nth-child(1) h3 {
+    font-size: 2.1em;
 }
 
-.program-page header p {
-    margin-top: 0;
+.blog-index main .posts.featured .post a {
+    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+.blog-index main .posts.featured li:nth-of-type(1) .post a {
+    --underline-background-color: white;
+}
+
+.blog-index main .posts.featured li:nth-of-type(1) .post figure {
+    order: initial;
+}
+
+.blog-index main .posts.featured ul {    
+    padding: 0 var(--vocabulary-page-edges-space);
+}
+
+.blog-index main .posts.featured ul li {
+    grid-column: span 3;
+}
+
+.blog-index main .posts.featured ul li:nth-of-type(1) {
+    grid-column: span 12;
+
+    background: white;
+}
+
+.blog-index main .posts.featured ul li:nth-of-type(1) article.post {
+    margin-bottom: 1em;
+    padding: 4em;
 }
 
 
+.blog-index main footer {
+    grid-column: 2 / span 9;
+}
 
+/* search-index context */
 
-
-
+.search-index main > header { /* generalize? */
+    display: block;
+    padding: 3.7em 0;
+    /* text-align: left; */
+}
 
 .search-index .search-form form {
     display: flex;
@@ -1378,7 +1567,6 @@ body > article.attention.low-importance a:before, body > article.attention.mediu
     font-style: normal;
     font-weight: 700;
     font-size: 1em;
-
 }
 
 .search-index .search-form form input {
@@ -1391,7 +1579,6 @@ body > article.attention.low-importance a:before, body > article.attention.mediu
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
     border: 2px solid black;
-
 }
 
 .search-index .search-form form button {
@@ -1405,208 +1592,10 @@ body > article.attention.low-importance a:before, body > article.attention.mediu
     border-bottom-right-radius: 4px;
 }
 
-.search-index .authored-posts article {
-    position: relative;
-}
-
-.search-index .authored-posts article .type {
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: .5em .7em;
-
-    background: var(--vocabulary-brand-color-soft-turquoise);
-    border-radius: 4px;
-    font-family: 'Source Sans Pro';
-
-}
-
-
-
-.authored-posts > h2 {
-    margin-bottom: 2.1em;
-
-    font-family: 'Roboto Condensed';
-    font-size: 2.1em;
-    font-style: normal;
-    font-weight: 700;
-    text-transform: none;
-}
-
-.authored-posts a {
-     /* better hyperlink underline typesetting inspired by Tufte CSS */
-     --underline-color: var(--vocabulary-brand-color-dark-tomato);
-     --underline-background-color: white;
-     color: var(--vocabulary-brand-color-dark-tomato);
-     text-decoration: none;
-
-     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
-     background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
-     background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
-     -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     background-repeat: no-repeat, no-repeat, repeat-x;
-     text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
-     background-position: 0% 93%, 100% 93%, 0% 93%;
-     /* background-position-y: 87%, 87%, 87%; */
-}
-
-.authored-posts article {
-    display: flex;
-    flex-wrap: wrap;
-    /* display: grid; */
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-    'title title'
-    'image teaser';
-    gap: 2em;
-    margin-bottom: 8em;
-}
-
-.authored-posts article header {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: column;
-    align-items: baseline;
-    width: 100%;
-}
-
-.authored-posts article h2, .authored-posts article h3 {
-    grid-area: title;
-    width: 100%;
-    margin-top: 0.83em;
-
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.5em;
-    font-size: 2.1em;
-    text-transform: none;
-    text-transform: initial;
-}
-
-.authored-posts.highlight article .byline {
-    margin-bottom: 2em;
-}
-
-.authored-posts article .categories {
-    order: -1;
-
-    font-family: 'Source Sans Pro';
-}
-
-.authored-posts .byline {
-    font-family: 'Source Sans Pro';
-}
-
-.authored-posts article figure {
-    display: inline-block;
-    width: 50%;
-    grid-area: image;
-    margin: 0;
-    padding: 0;
-    flex: 1;
-}
-
-.authored-posts article img {
-    /* width: 50%; */
-    width: 100%;
-    /* float: left; */
-    /* margin-right: 1em; */
-
-}
-
-.authored-posts article p {
-    flex: 1;
-    display: inline-block;
-    grid-area: teaser;
-    margin-top: 0;
-}
-
-.authored-posts article .attribution {
-    /* grid-area: image; */
-    /* grid-row-start: 3; */
-    display: inline-block;
-    margin-top: 1em;
-    /* background: #F5F5F5; */
-
-    font-family: 'Source Sans Pro';
-}
-
-.authored-posts article p:before {
-    clear: both;
-}
-
-.authored-posts article ul {
-    width: 100%;
-}
-
-.authored-posts a.more, a.more {
-    padding: .4em .7em;
-
-    background: black;
-    color: white;
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.2em;
-    text-transform: none;
-    text-decoration: none;
-    text-shadow: none;
-}
-
-main .authored-posts.highlight article {
-    gap: 0 2em;
-    align-content: flex-start;
-}
-
-.authored-posts.highlight figure {
-    margin-bottom: 2em;
-}
-
-nav.pagination {
-    grid-column: span 2;
-    margin: 0 auto;
-}
-
-nav.pagination ol {
-    display: flex;
-    margin: 0;
-    padding: 0;
-    text-indent: none;
-
-    font-size: 1em;
-    list-style: none;
-
-}
-
-main nav.pagination ol li {
-    margin: 0 .5em;
-}
-
-main nav.pagination ol li a {
-    padding: .4em .7em;
-
-    background: #F5F5F5;
-    --underline-background-color: #F5F5F5;
-    color: black;
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.2em;
-    text-transform: none;
-    text-decoration: none;
-}
-
-main nav.pagination ol li.current a {
-    background: black;
-    --underline-background-color: black;
-    color: white;
-}
+/* team-index context */
 
 .team-index main .persons {
-    grid-column: span 3;
+    grid-column: 2 / 11;
     margin-bottom: 5em;
 }
 
@@ -1670,7 +1659,6 @@ main nav.pagination ol li.current a {
     zoom: 10;
 }
 
-
 .team-index main .persons .person a {
      /* better hyperlink underline typesetting inspired by Tufte CSS */
      --underline-color: var(--vocabulary-brand-color-dark-tomato);
@@ -1694,15 +1682,18 @@ main nav.pagination ol li.current a {
     font-size: .75em;
 }
 
-.team-index main .closing {
-    grid-column: span 3;
+.team-index main aside.closing {
+    background: none;
 }
 
-.team-index main .closing p {
+.team-index main aside.closing p {
     font-style: italic;
 }
 
+/* person-page context */
+
 .person-page main > header {
+    grid-column: 2 / span 9;
     min-height: 410px;
     position: relative;
     box-sizing: border-box;
@@ -1713,13 +1704,19 @@ main nav.pagination ol li.current a {
     'picture info'
     'picture info'; */
     gap: 0 5em;
+    padding: 3.7em 0;
+
+    text-align: left;
+}
+
+
+.person-page main > header:before {
+    left: -5.5%;
 }
 
 .person-page main > header h1 {
     grid-column-start: 2;
-
     margin-bottom: .1em;
-
 }
 
 .person-page main > header .title {
@@ -1735,6 +1732,7 @@ main nav.pagination ol li.current a {
 .person-page main > header .pronouns {
     grid-column-start: 2;
     margin-bottom: 1em;
+
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 700;
@@ -1746,7 +1744,6 @@ main nav.pagination ol li.current a {
     position: absolute;
     margin: 0;
     padding:0;
-
     top: 3.4em;
     left: 0;
     width: 30%;
@@ -1754,8 +1751,8 @@ main nav.pagination ol li.current a {
 
 .person-page main > header figure img {
     box-sizing: border-box;
-
     width: 100%;
+    max-height: 21.8rem;
 
     border: 16px solid white;
 }
@@ -1764,855 +1761,97 @@ main nav.pagination ol li.current a {
     grid-column-start: 2;
 
     font-size: .9em;
-
 }
 
-.person-page main .authored-posts {
-    grid-area: content;
+.person-page main > header p {
+    margin-bottom: .3em;
 }
 
-.person-page main .authored-posts h2 {
+/* program-index context */
 
-    font-family: 'Roboto Condensed';
-    font-size: 2.1em;
-    font-style: normal;
-    font-weight: 700;
-    /* text-transform: uppercase; */
-
-}
-
-.person-page main .authored-posts article img {
-    /* generalize this better */
-    width: 100%;
-}
-
-
-
-/*/////////////////////////*/
-
-main {
-    width: 60%;
-    margin: 0 auto;
-    /* margin-top: 2em; */
-    margin-bottom: 8em;
-    padding: 0 2em;
-}
-
-main > header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    margin-bottom: 4em;
-    padding-top: 2em;
-    padding-bottom: 1em;
-    position: relative;
-
-    text-align: center;
-}
-
-main > header:before {
-    width: 100vw;
-    height: 100%;
-    position: absolute;
-    left: -33.333%;
-    top: 0;
-    z-index: -1;
-    content: "";
-
-    background: #F5F5F5;
-}
-
-main > header nav.breadcrumbs ol {
-    display: flex;
-    margin: 0;
-    padding: 0;
-    padding-left: 4px;
-
-    list-style: none;
-    font-family: 'Source Sans Pro';
-    font-style: normal;
-    font-weight: 400;
-    font-size: .8125em;
-}
-
-main > header nav.breadcrumbs ol li {
-    display: flex;
-    vertical-align: middle;
-}
-
-main > header nav.breadcrumbs ol li:after {
-    --icon-sprite: var(--fa-right-angle);
-    /* --icon-sprite-color: var(--vocabulary-brand-color-dark-tomato);    */
-    --icon-sprite-size: 1em;
-
-    display: inline-block;
-    content: '';
-    /* min-width: 30px; */
-    /* min-height: 30px; */
-    height: 1em;
-    width: 1em;
-    margin: 0 .4em;
-
-    font-size: var(--icon-sprite-size);
-    background-color: var(--icon-sprite-color);
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-image: var(--icon-sprite);
-    mask-image: var(--icon-sprite);
-    -webkit-mask-size: contain;
-    mask-size: contain;
-    opacity: .1;
-}
-
-main > header nav.breadcrumbs ol li a {
-    /* better hyperlink underline typesetting inspired by Tufte CSS */
-    --underline-color: var(--vocabulary-brand-color-dark-tomato);
-    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-    color: var(--vocabulary-brand-color-dark-tomato);
-    text-decoration: none;
-
-    /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
-    background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
-    background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
-    -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-    -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-    background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-    background-repeat: no-repeat, no-repeat, repeat-x;
-    text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
-    background-position: 0% 93%, 100% 93%, 0% 93%;
-    /* background-position-y: 87%, 87%, 87%; */
-}
-
-main > header h1 {
-    width: 100%;
-
-    font-family: 'Roboto Condensed';
-    font-size: 3.56em;
-    font-style: normal;
-    font-weight: 700;
-    text-transform: uppercase;
-}
-
-main > header a {
-    /* text-decoration: none; */
-    color: var(--vocabulary-brand-color-dark-tomato);
-
-    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-}
-
-main > header .categories {
-    order: -1;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.2em;
-    font-style: normal;
-    font-weight: 400;
-    /* text-transform: uppercase; */
-}
-
-main > header .byline {
-    display: block;
-    width: 100%;
-    margin-bottom: 2em;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.2em;
-    font-style: normal;
-    font-weight: 400;
-    font-style: italic;
-}
-
-main h2 {
-    width: 100%;
-
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 2.1em;
-    text-transform: none;
-
-}
-
-main h3 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.75em;
-    text-transform: none;
-}
-
-main .series {
-    display: inline-block;
-    /* position: absolute;
-    left: -25%;
-    bottom: -10%; */
-    box-sizing: border-box;
-    /* min-height: 150px; */
-    width: 25%;
-    /* float: left; */
-    /* margin: 2em; */
-    margin-bottom: 2em;
-    padding: 2em;
-    width: 100%;
-
-
-    background: #FEEDE9;
-    /* color: white; */
-    /* color: var(--vocabulary-brand-color-dark-tomato); */
-
-}
-
-
-main .series a {
-    color: var(--vocabulary-brand-color-dark-tomato);
-    --underline-background-color: #FEEDE9;
-}
-
-main .series p {
-    margin :0;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.2em;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%;
-}
-
-main a {
-     /* better hyperlink underline typesetting inspired by Tufte CSS */
-     --underline-color: var(--vocabulary-brand-color-dark-tomato);
-     --underline-background-color: white;
-     color: var(--vocabulary-brand-color-dark-tomato);
-     text-decoration: none;
-
-     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
-     background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
-     background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
-     -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-     background-repeat: no-repeat, no-repeat, repeat-x;
-     text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
-     background-position: 0% 93%, 100% 93%, 0% 93%;
-     /* background-position-y: 87%, 87%, 87%; */
-}
-
-main p {
-    margin-bottom: 2em;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.5em;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%;
-}
-
-main p:has(img) {
-    overflow: hidden;
-  }
-
-main ul, main ol {
-    margin: 0 0 2em 1em;
-    padding: 0;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.5rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%;
-}
-
-main ul ul, main ol ol {
-    font-size: 1.2rem;
-}
-
-main blockquote {
-    /* width: 120%; */
-    margin: 0;
-    /* margin-left: -10%; */
-    margin-bottom: 1.5em;
-    padding: 0;
-}
-
-/* manually include quote icon to avoid extraneous html classes */
-main blockquote p:before {
-    --icon-sprite: var(--cc-quote);
-
-    display: block;
-    content: '';
-    height: 1em;
-    width: 1em;
-
-    font-size: var(--icon-sprite-size);
-    background-color: var(--icon-sprite-color);
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-image: var(--icon-sprite);
-    mask-image: var(--icon-sprite);
-    -webkit-mask-size: contain;
-    mask-size: contain;
-
-}
-
-main blockquote p {
-    font-family: 'Source Sans Pro';
-    font-weight: bold;
-    font-size: 1.9em;
-    line-height: 105%;
-}
-
-/* main img[width] {
-    width: initial;
-} */
-
-main img:not([width]) {
-    width: 100%;
-}
-
-main figure {
-    /* width: 120%; */
-
-    margin: 0;
-    /* margin-left: -10%; */
-    margin-bottom: 3em;
-    padding: 0;
-}
-
-main figure .attribution {
-    display: block;
-    margin-top: 1em;
-
-    font-family: 'Source Sans Pro';
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%;
-}
-
-/* main figure:nth-of-type(even):has(img) {
-    margin-top: 2em;
-    margin-right: 2em;
-    width: 50%;
-    float: left;
-}
-
-main figure:nth-of-type(even):has(img):after {
-    display: block;
-    content: '';
-    height: 3em;
-    clear: both;
-}
-
-main figure:nth-of-type(odd):has(img) {
-    margin-top: 2em;
-    margin-right: -10%;
-    margin-left: 2em;
-    width: 50%;
-    float: right;
-}
-
-main figure:nth-of-type(odd):has(img):after {
-    display: block;
-    content: '';
-    height: 2em;
-    clear: both;
-} */
-
-main > figure:nth-of-type(1):has(img) {
-    width: 120%;
-    margin: 0;
-    margin-left: -10%;
-    margin-bottom: 3em;
-    padding: 0;
-    float: none;
-}
-
-main figure:has(img.alignleft) {
-    margin-top: 2em;
-    margin-right: 2em;
-    margin-left: -10%;
-    width: 50%;
-    float: left;
-}
-
-main figure:has(img.alignleft):after {
-    display: block;
-    content: '';
-    height: 3em;
-    clear: both;
-}
-
-main figure:has(img.alignright) {
-    margin-top: 2em;
-    margin-right: -10%;
-    margin-left: 2em;
-    width: 50%;
-    float: right;
-}
-
-main figure:has(img.alignright):after {
-    display: block;
-    content: '';
-    height: 2em;
-    clear: both;
-}
-
-main figure:has(img.aligncenter) {
-    width: 100%;
-
-    margin-left: 0;
-}
-
-main figure:has(iframe) {
-    width: 120%;
-    margin-left: -10%;
-    margin-right: 0;
-    float: none;
-}
-
-main .pub-date {
-    display: inline-block;
-    margin-bottom: 4em;
-
-    font-family: 'Source Sans Pro';
-    font-size: 1.5em;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%;
-}
-
-main article.tags {
+.program-index main > article.projects {
+    grid-column: 3 / 10;
     margin-bottom: 8em;
 }
 
-main article.tags ul {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 0;
-    left: 0;
-
-    list-style: none;
-}
-
-main article.tags ul li {
-    margin-right: .5em;
-}
-
-
-main article.tags ul li:after {
-    content: ',';
-    margin-left: .1em;
-
-}
-
-main article.tags ul li:last-child:after {
-    content: '';
-}
-
-
-main article.related-posts {
-    /* display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    margin-top: 8em;
-    padding: 0 4em;
-    gap: 3em;
-    box-sizing: border-box; */
-    width: 140%;
-    margin-left: -20%;
-    padding: 2em 4em;
-    box-sizing: border-box;
-
-
-    background: var(--vocabulary-neutral-color-lighter-gray);
-
-
-
-}
-
-main article.related-posts .authored-posts.highlight {
+.program-index main > article.projects ul {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    margin-top: 8em;
-    /* padding: 0 4em; */
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 2em;
-    box-sizing: border-box;
-
-    margin: 0 auto;
-    margin-top: 0;
-    /* padding: 0; */
-
-    /* background: var(--vocabulary-neutral-color-lighter-gray); */
-}
-
-main article.related-posts .authored-posts.highlight article {
-    margin-bottom: 3em;
-}
-
-main article.related-posts .authored-posts.highlight article header {
-    flex-direction: column;
-    align-items: baseline;
-}
-
-main article.related-posts .authored-posts.highlight article figure {
-    order: -1;
-
-    display: none;
-
-}
-
-main article.related-posts .authored-posts.highlight article a {
-    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-}
-
-main article.related-posts .authored-posts.highlight article h2 {
-    font-size: 1.4em;
-}
-
-main article.related-posts .authored-posts.highlight article p {
-    display: none;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-body > footer {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    grid-template-areas:
-    "logo nav nav nav"
-    "contact subscribe subscribe donate"
-    "contact license license donate";
-    gap: 40px;
-    padding: 40px var(--vocabulary-page-edges-space);
-
-    font-family: 'Source Sans Pro';
-    font-style: normal;
-    font-weight: 400;
-    color: white;
-    background: black;
-}
-
-body > footer h2 {
-    font-family: 'Roboto Condensed';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.25em;
-}
-
-body > footer a {
-    color: var(--vocabulary-brand-color-turquoise);
-    text-decoration: none;
-}
-
-body > footer p {
-    line-height: 1.5;
-}
-
-/* needs to be moved to be broader in general specificity scope */
-body > footer p a {
-    /* better hyperlink underline typesetting inspired by Tufte CSS */
-    --underline-color: var(--vocabulary-brand-color-turquoise);
-    --underline-background-color: black;
-    color: var(--vocabulary-brand-color-turquoise);
-    /* text-decoration: none; */
-
-    /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
-    background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);
-    background: linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(var( --underline-color), var( --underline-color)), linear-gradient(currentColor, currentColor);
-    -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-    -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-    background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-    background-repeat: no-repeat, no-repeat, repeat-x;
-    text-shadow: 0.03em 0 var(--underline-background-color), -0.03em 0 var(--underline-background-color), 0 0.03em var(--underline-background-color), 0 -0.03em var(--underline-background-color), 0.06em 0 var(--underline-background-color), -0.06em 0 var(--underline-background-color), 0.09em 0 var(--underline-background-color), -0.09em 0 var(--underline-background-color), 0.12em 0 var(--underline-background-color), -0.12em 0 var(--underline-background-color), 0.15em 0 var(--underline-background-color), -0.15em 0 var(--underline-background-color);
-    background-position: 0% 93%, 100% 93%, 0% 93%;
-    /* background-position-y: 87%, 87%, 87%; */
-
-}
-
-body > footer .identity-logo {
-    grid-area: logo;
-    display: inline-block;
-    text-indent: -1000px;
-    vertical-align: bottom;
-    height: 50px;
-    width: 191px;
-
-
-    /* allows for color manipulation of svg */
-    background-color: white;
-    -webkit-mask-image: url('./../svg/cc/logos/cc/logomark.svg');
-    mask-image: url('./../svg/cc/logos/cc/logomark.svg');
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    cursor: pointer;
-
-    /* standard pattern for setting logo in lieu of background color manipulation */
-    /* background: url('../../svg/cc/logos/cc/logomark.svg') left top no-repeat; */
-}
-
-body > footer .identity-logo:hover {
-    background-color: var(--vocabulary-brand-color-turquoise);
-}
-
-body > footer .footer-menu {
-    grid-area: nav;
-
-    font-size: 1.3em;
-    font-weight: 700;
-}
-
-body > footer .footer-menu ul {
-    display: flex;
-    justify-content: space-between;
     margin: 0;
     padding: 0;
 
-    list-style: none;
-}
-
-body > footer .footer-menu ul li a {
-    text-decoration: none;
-    color: var(--vocabulary-brand-color-turquoise);
-
-}
-
-body > footer .contact {
-    grid-area: contact;
-}
-
-body > footer .contact .social-menu ul {
-    display: flex;
-    margin: 0;
-    padding: 0;
-    margin-top: 3em;
-
-    list-style: none;
-
-}
-
-body > footer .contact .social-menu ul li {
-    margin-right: 1.5em;
-}
-
-body > footer .social-menu li a {
-    --icon-sprite-color: white;
-    --icon-sprite-size: 1.9em;
-}
-
-body > footer .subscribe {
-    grid-area: subscribe;
-}
-
-body > footer .subscribe form {
-    display: flex;
-    justify-content: space-around;
-    width: 100%;
-}
-
-body > footer .subscribe form input {
-    display: inline-flex;
-    position: relative;
-    justify-content: flex-start;
-    align-items: center;
-    vertical-align: top;
-    box-sizing: border-box;
-
-    -webkit-appearance: none;
-    background-color: transparent;
-    color: rgb(118, 118, 118);
-    font-family: "Source Sans Pro", sans-serif;
     font-size: 1em;
-    font-weight: 600;
-    line-height: 1.3;
-    border: 2px solid rgb(118, 118, 118);;
-    /* border-radius: 4px; */
-    box-shadow: none;
-
+    list-style: none;
 }
 
-body > footer .subscribe form input.input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-    padding: .5em;
-    width: 100%;
+.program-index main > article.projects article {
+    padding: 2em;
+
+    background: var(--vocabulary-brand-color-soft-turquoise);
+    border-top: 3px solid black;
 }
 
-body > footer .subscribe form input.input:focus {
-    color: white;
+.program-index main > article.projects article a {
+    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
 }
 
-body > footer .subscribe form input.button {
-    justify-content: center;
-    padding: 1.1em;
-
-    cursor: pointer;
-    font-family: "Roboto Condensed", sans-serif;
-    font-size: 1.125rem;
-    text-align: center;
-    text-transform: uppercase;
-    font-weight: 600;
-    line-height: 0;
-    white-space: nowrap;
-    background-color: rgb(118, 118, 118);
-    border: none;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    color: rgb(255, 255, 255);
-}
-
-body > footer .donate {
-    grid-area: donate;
-}
-
-body > footer .donate a.donate {
-    display: inline-flex;
-    align-items: center;
-    padding: 1rem 1.5rem;
-
-    text-transform: uppercase;
-    font-family: 'Roboto Condensed';
-    font-size: 1.5em;
-    line-height: 1em;
-    font-style: normal;
-    font-weight: 700;
-    border: none;
-    border-radius: 4px;
-    color: black;
-    background: var(--vocabulary-brand-color-gold);
-}
-
-body > footer .donate a.donate:hover {
-    cursor: pointer;
-
-    background-color: rgb(248, 204, 44);
-}
-
-/* set the icon settings */
-body > footer .donate a.donate.icon-attach:before {
-    /* --icon-sprite: var(--cc-heart-filled); */
-    --icon-sprite-color: black;
-    --icon-sprite-size: 1.2em;
-
-    margin-right: .3em;
-}
-
-body > footer .license {
-    grid-area: license;
-}
-
-body > footer .license img path {
-    fill: white;
-    /* width: 1.2em; */
-}
-
-body > footer .license svg {
-    display: inline;
-    width: 1.9em;
-    height: 1.9em;
-    margin-right: .3em;
-}
+/* program-page context */
 
 
-
-
-/* ************************* */
-
-.data-points ul {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    margin: 0;
-    padding: 0;
-
-    list-style-type: none;
-}
-
-.data-points .data-point {
-    display: flex;
-    flex-direction: column;
-}
-
-.data-points .data-point .stat {
-    order: 3;
-}
-
-.topic-summary {
-    display: grid;
-    grid-template:
-        "title graphic graphic"
-        "description graphic graphic"
-        "button graphic graphic";
-}
-
-.topic-summary h2 {
-    grid-area: title;
-}
-
-.topic-summary img {
-    grid-area: graphic;
-
-    background: black;
-    width: 100%;
-}
-
-.topic-summary p {
-    grid-area: description;
-}
-
-.topic-summary a {
-    grid-area: button;
-}
+/* responsive contexts */
 
 @media (min-width: 1500px) {
     body {
-      width: 1500px;
-      margin: 0 auto;
+        width: 1500px;
+        margin: 0 auto;
     }
 
-  }
+    body > main {
+        overflow-x: hidden;
+    }
+
+}
 
 @media (max-width: 1140px) {
     .blog-index main footer .attribution-list ul.expand {
         grid-template-columns: 1fr 1fr;
     }
+
+    .search-index main > header {
+        grid-column: 3 / 10;
+    }
+
+    .search-index main > header:before {
+        left: -9.3%;
+    }
 }
 
 @media (max-width: 900px) {
 
-    .blog-index main .authored-posts.highlight {
+    .blog-index main .posts ul {
         display: flex;
         flex-wrap: wrap;
-
     }
 
-    .blog-index main .authored-posts.highlight > article:nth-child(1) {
-        width: 100%;
+    main article.posts.related ul {
+        grid-template-columns: 1fr 1fr;
     }
-
 }
 
 @media (max-width: 705px) {
 
-    .masthead {
+    body > header .masthead {
         padding-top: 60px;
         display: block;
     }
 
-    button.expand-menu {
+    body > header button.expand-menu {
         position: absolute;
         top: 4.5em;
         right: 0;
         display: inline-block;
-        padding: .3em .5em;
+        padding: .5rem 1rem;
         border: none;
         border-radius: 5px;
         background: #F5F5F5;
@@ -2621,19 +1860,18 @@ body > footer .license svg {
         font-style: normal;
         font-weight: 700;
         font-size: 1em;
-        padding: .5rem 1rem;
     }
 
-    .primary-menu {
+    body > header .primary-menu {
         display: none;
 
     }
 
-    .primary-menu.expand {
+    body > header .primary-menu.expand {
         display: initial;
     }
 
-    .primary-menu.expand ul {
+    body > header .primary-menu.expand ul {
         display: block;
         width: 100%;
         margin: 0;
@@ -2641,55 +1879,36 @@ body > footer .license svg {
         margin-top: 1.5em;
     }
 
-    .primary-menu.expand ul li {
+    body > header .primary-menu.expand ul li {
         margin: 0;
         padding: 1em 0;
+
         border-top: 1px solid rgba(1,1,1,.1);
     }
-    /* .ancilliary-menu {
-        display: none;
-    } */
 
     main {
         width: 80%;
     }
 
-    main > header:before {
-        left: initial;
-    }
-
-    main article.related-posts {
+    main article.posts.related {
         width: 100%;
         margin-left: 0;
     }
 
-    main article.related-posts .authored-posts.highlight {
+    main article.posts.related {
         display: block;
     }
 
-    .blog-index main .authored-posts.highlight:nth-of-type(1) > article:nth-child(1) {
+    .blog-index main article.posts.featured > ul li:nth-child(1) {
         padding: 2em;
     }
 
-    .blog-index main .authored-posts.highlight {
-        padding: 0 5%;
+    .blog-index main .posts {
+        padding: 0 var(--vocabulary-page-edges-space);
     }
 
     .blog-index main footer .attribution-list ul.expand {
         display: block;
-    }
-
-    .program-index main > article {
-        width: 90%;
-        margin: 0;
-    }
-
-    .program-index main > article.projects ul {
-        display: block;
-    }
-
-    .program-index main > article.projects ul li {
-        margin-bottom: 2em;
     }
 
     .search-index .search-form form button {
@@ -2700,7 +1919,7 @@ body > footer .license svg {
 
 @media (max-width: 680px) {
 
-    .explore-panel {
+    body > header .explore-panel {
         flex-wrap: wrap;
     }
 
@@ -2721,21 +1940,67 @@ body > footer .license svg {
         margin-bottom: 4em;
     }
 
-    .default-page main {
+    main {
         display: block;
-        /* margin: 0 auto; */
+        width: 100%;
     }
 
-    .default-page main > aside .attention {
+    main > aside .attention {
         margin-bottom: 5em;
     }
 
-    .authored-posts article figure {
+    main > header:before {
+        left: 0;
+    }
+
+    main .content {
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+    main:has( > aside.sidebar) > aside.sidebar { 
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+    main > *:not(header) {
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+    main > .posts {
+        padding: 0 var(--vocabulary-page-edges-space); 
+    }
+
+    .posts article figure {
         width: 100%;
         flex: initial;
     }
 
-    .team-index main .persons ul {
+    .person-page main > header {
+        padding-left: var(--vocabulary-page-edges-space);
+        padding-right: var(--vocabulary-page-edges-space);
+    }
+
+    .person-page main > header:before { 
+        left: 0;
+    }
+
+    .search-index main > header {
+        padding-left: var(--vocabulary-page-edges-space);
+        padding-right: var(--vocabulary-page-edges-space);
+    }
+
+    .search-index main > header:before { 
+        left: 0;
+    }
+    
+    .team-index main > header {
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+    .team-index main article.persons {
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+    .team-index main article.persons ul {
         grid-template-columns: 1fr 1fr;
     }
 
@@ -2751,30 +2016,32 @@ body > footer .license svg {
         order: -1;
     }
 
-    nav.pagination {
-        width: 100%;
-    }
-
-    nav.pagination ol {
+    main nav.pagination ol {
         /* width: 100%; */
         flex-wrap: wrap;
     }
 
-    nav.pagination ol li {
+    main nav.pagination ol li {
         line-height: 250%;
     }
 }
 
 @media (max-width: 580px) {
-    .explore-panel .explore-menu ul {
+    body > header .explore-panel .explore-menu ul {
         grid-template-columns: 1fr 1fr;
-        /* display: flex;
-        flex-direction: column;
-        flex-wrap: wrap; */
     }
 
     body > footer .footer-menu ul {
         display: block;
+    }
+
+    main article.posts.related ul {
+        grid-template-columns: 1fr;
+    }
+
+    .posts .post figure {
+        width: 100%;
+        flex: initial;
     }
 }
 
@@ -2786,51 +2053,28 @@ body > footer .license svg {
 
     .blog-index .attribution-list h2 {
       width: 50%;
+
       hyphens: auto;
       word-break: break-word;
-
     }
 
   }
 
-@media (max-width:400px) {
+  @media (max-width:400px) {
 
-    .explore-panel .explore-menu ul {
+    body > header .explore-panel .explore-menu ul {
         display: flex;
         flex-direction: column;
         flex-wrap: wrap;
     }
 
-    .team-index main .persons ul {
+    .team-index main article.persons ul {
         display: initial;
     }
 }
 
 @media (max-width:340px) {
-    .ancilliary-menu button:before, .ancilliary-menu a:before {
+    body > header .ancillary-menu button:before, body > header .ancillary-menu a:before {
         display: none;
     }
-
-}
-
-
-
-
-
-
-/* temp */
-
-.explore-panel {
-    display: none;
-
-}
-
-.explore-panel.expand {
-    display: inherit;
-    transition: display 2s ease-in-out;
-}
-
-
-article, footer, article.topic-summary {
-    /* display: none; */
 }

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/js/vocabulary.js
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/vocabulary/js/vocabulary.js
@@ -2,27 +2,27 @@ const exploreButton = document.querySelector('button.explore');
 const explorePanel = document.querySelector('.explore-panel');
 
 // explorePanel.classList.add('hide');
-
-exploreButton.addEventListener('click', (event) => {
-    explorePanel.classList.toggle('expand');
-    // explorePanel.classList.toggle('hide');
-});
-
+if(exploreButton!==null && explorePanel!==null) {
+    exploreButton.addEventListener('click', (event) => {
+        explorePanel.classList.toggle('expand');
+        // explorePanel.classList.toggle('hide');
+    });
+}
 
 const menuButton = document.querySelector('button.expand-menu');
 const menuPanel = document.querySelector('.primary-menu');
 
-menuButton.addEventListener('click', (event) => {
-    menuPanel.classList.toggle('expand');
-    // explorePanel.classList.toggle('hide');
-});
-
+if(menuButton !== null && menuPanel !== null) {
+    menuButton.addEventListener('click', (event) => {
+        menuPanel.classList.toggle('expand');
+        // explorePanel.classList.toggle('hide');
+    });
+}
 
 const attributionButton = document.querySelector('button.expand-attribution');
 const attributionPanel = document.querySelector('.attribution-panel');
 
 if (attributionButton !== null && attributionPanel !== null ) {
-
     attributionButton.addEventListener('click', (event) => {
         attributionButton.classList.toggle('selected');
         attributionPanel.classList.toggle('expand');

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -14,7 +14,7 @@
       </ul>
     </nav>
 
-    <nav class="ancilliary-menu">
+    <nav class="ancillary-menu">
       <ul>
         {% if languages_and_links %}
         {% include "includes/languages_dropdown.html" %}

--- a/templates/includes/legalcode_contextual_menu.html
+++ b/templates/includes/legalcode_contextual_menu.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<aside>
+<aside class="sidebar">
 <nav>
 <ul>
 <li>

--- a/templates/list-licenses.html
+++ b/templates/list-licenses.html
@@ -9,7 +9,7 @@
 
 
 {% block contextual_menu %}
-<aside>
+<aside class="sidebar">
   <nav>
     <ul>
       {% regroup tools|dictsortreversed:"version" by version as version_list %}

--- a/templates/list-publicdomain.html
+++ b/templates/list-publicdomain.html
@@ -9,7 +9,7 @@
 
 
 {% block contextual_menu %}
-<aside>
+<aside class="sidebar">
   <nav>
     <ul class="menu-list">
       {% regroup tools|dictsort:"identifier" by identifier as identifier_list %}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #507

## Description
App: update `vocabulary-theme` to `v1.9.4`, update markup and localized stylings to accommodate changes
* updates all local usage of `vocabulary` to match `v1.9.4` of `vocabulary-theme`
* updates relevant markup to match changes


Also see related Data pull request (PR):
- creativecommons/cc-legal-tools-data/pull/239

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests

## Unit tests and coverage
command:
```shell
./dev/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1800      0    590      0  100.00%

20 files skipped due to complete coverage.
```

## Screenshots
See related Data pull request (PR):
- creativecommons/cc-legal-tools-data/pull/239

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
