### PR TITLE
App: update standalone dev env `vocabulary-theme` to `v1.11.1`

### DIFF
--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/css/chooser.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/css/chooser.css
@@ -176,7 +176,7 @@
 
 .chooser-page form#chooser #attribution-details div {
     margin-bottom: .5em;
-} 
+}
 
 .chooser-page form#chooser #waive-your-copyright div {
     margin-bottom: 1em;
@@ -263,7 +263,7 @@
     font-size: 1.2em;
 }
 
-.chooser-page details { 
+.chooser-page details {
     font-family: 'Source Sans Pro';
 
     border: 2px solid var(--vocabulary-neutral-color-lighter-gray);
@@ -277,7 +277,7 @@
 .chooser-page details.medium {
     margin-bottom: 1em;
 }
-  
+
 .chooser-page details summary {
     padding: .2em .5em;
 
@@ -292,7 +292,7 @@
 .chooser-page summary:hover {
     cursor: pointer;
 }
-  
+
 .chooser-page summary::marker {
     font-size: .8em;
 }

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/css/chooser.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/css/chooser.css
@@ -1,0 +1,367 @@
+:root {
+
+    /* localized cc sprite names */
+    --cc-by: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-by');
+    --cc-nc: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-nc');
+    --cc-nd: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-nd');
+    --cc-pd: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-pd');
+    --cc-pdm: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-pdm');
+    --cc-sa: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-sa');
+    --cc-zero: url('../../vocabulary/svg/cc/icons/cc-icons.svg#cc-zero');
+}
+
+.chooser-page .icon-attach.cc-by:before {
+    --icon-sprite: var(--cc-by);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page .icon-attach.cc-nc:before {
+    --icon-sprite: var(--cc-nc);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page .icon-attach.cc-nd:before {
+    --icon-sprite: var(--cc-nd);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page .icon-attach.cc-pd:before {
+    --icon-sprite: var(--cc-pd);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page .icon-attach.cc-pdm:before {
+    --icon-sprite: var(--cc-pdm);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page .icon-attach.cc-sa:before {
+    --icon-sprite: var(--cc-sa);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page .icon-attach.cc-zero:before {
+    --icon-sprite: var(--cc-zero);
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.chooser-page dl div {
+    margin-bottom: .8em;
+}
+
+.chooser-page dt, .chooser-page dd {
+    display: inline-block;
+}
+
+.chooser-page dt:after {
+    content: ':';
+}
+
+.chooser-page dd {
+    margin-left: .2em;
+}
+
+.chooser-page dd span {
+    display: block;
+}
+
+.chooser-page ol li:has(.disable) {
+    display: none;
+}
+
+.chooser-page .disable {
+    display: none;
+}
+
+.chooser-page .hide {
+    display: none;
+}
+
+.chooser-page .tool header {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.chooser-page .tool header > h4 {
+    width: 100%;
+}
+
+.chooser-page .tool header > .tool-icons {
+    order: -1;
+    margin: 0 1em 0 0;
+}
+
+.chooser-page .tool .tool-icons svg {
+    display: inline;
+    width: 1.9em;
+    height: 1.9em;
+    margin-right: .3em;
+}
+
+.chooser-page .content {
+    display: grid;
+    gap: 2em;
+    grid-template-columns: 1fr 2fr;
+}
+
+.chooser-page .mark svg {
+    display: inline;
+    width: 1.3em;
+    height: 1.3em;
+}
+
+.chooser-page .mark svg:first-of-type {
+    margin-left: .5em;
+}
+
+.chooser-page .tool-rec-details input {
+    color: lightgray;
+}
+
+.chooser-page form#chooser > ol {
+    position: relative;
+
+    list-style: none;
+    counter-reset: chooser-counter;
+}
+
+.chooser-page form#chooser > ol li {
+    counter-increment: chooser-counter;
+}
+.chooser-page form#chooser > ol li::before {
+    position: absolute;
+    --size: 32px;
+    left: calc(-1 * var(--size) - 25px);
+    min-height: 2em;
+    min-width: 2em;
+    padding-top: .4em;
+    box-sizing: border-box;
+
+    content: counter(chooser-counter);
+    font-weight: bold;
+    border-radius: 200px;
+    background: var(--vocabulary-neutral-color-lighter-gray);
+    color: black;
+    text-align: center;
+    vertical-align: middle;
+}
+
+.chooser-page form#chooser legend {
+    font-weight: bold;
+}
+
+.chooser-page form#chooser fieldset {
+    margin-bottom: 1em;
+}
+
+.chooser-page form#chooser label {
+    font-size: .7em;
+    font-weight: 400;
+}
+
+.chooser-page form#chooser #attribution-details span {
+    display: inline-block;
+    padding: .7em 0;
+
+    font-size: .8em;
+    line-height: 1.3;
+}
+
+.chooser-page form#chooser #attribution-details div {
+    margin-bottom: .5em;
+} 
+
+.chooser-page form#chooser #waive-your-copyright div {
+    margin-bottom: 1em;
+}
+
+.chooser-page form#chooser #attribution-details input {
+    padding: .2em .2em;
+
+    font-size: 1em;
+}
+
+.chooser-page form#chooser #atrribution-details input::placeholder {
+    opacity: .5;
+}
+
+.chooser-page aside #empty {
+    min-height: 10em;
+    padding: 2em;
+
+    background: var(--vocabulary-brand-color-soft-turquoise);
+    background: var(--vocabulary-neutral-color-lighter-gray);
+}
+
+.chooser-page aside #empty p {
+    font-size: 1.2em;
+}
+
+.chooser-page #tool-recommendation {
+    margin-bottom: 4em;
+
+    font-family: 'Source Sans Pro';
+}
+
+.chooser-page #tool-recommendation .tool {
+    padding: 2em;
+
+    background: var(--vocabulary-brand-color-soft-turquoise);
+}
+
+.chooser-page #tool-recommendation .tool a {
+    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+}
+
+.chooser-page #tool-recommendation h3 {
+    margin: 0;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.4em;
+}
+
+.chooser-page #tool-recommendation h4 {
+    margin: .2em;
+
+    font-family: 'Source Sans Pro';
+    font-size: 1.4em;
+}
+
+.chooser-page #tool-recommendation p {
+    font-size: 1.2em;
+}
+
+.chooser-page #tool-recommendation a {
+    font-weight: 700;
+}
+
+.chooser-page #tool-recommendation .conditions-definitions {
+    margin-bottom: 2em;
+
+    font-family: 'Source Sans Pro';
+}
+
+.chooser-page #tool-recommendation .conditions-definitions dt {
+    font-weight: 700;
+}
+
+.chooser-page #mark-your-work textarea {
+    min-height: 9em;
+    width: 90%;
+    margin: 1em;
+    box-sizing: border-box;
+}
+
+.chooser-page #mark-your-work p {
+    font-size: 1.2em;
+}
+
+.chooser-page details { 
+    font-family: 'Source Sans Pro';
+
+    border: 2px solid var(--vocabulary-neutral-color-lighter-gray);
+    border-radius: 5px;
+}
+
+.chooser-page details details {
+    margin: 1em;
+}
+
+.chooser-page details.medium {
+    margin-bottom: 1em;
+}
+  
+.chooser-page details summary {
+    padding: .2em .5em;
+
+    background: var(--vocabulary-neutral-color-lighter-gray);
+    font-size: 1.6em;
+}
+
+.chooser-page details.format summary {
+    font-size: 1.3em;
+}
+
+.chooser-page summary:hover {
+    cursor: pointer;
+}
+  
+.chooser-page summary::marker {
+    font-size: .8em;
+}
+
+.chooser-page details p {
+    padding: 0 1em;
+
+    font-size: 1em;
+}
+
+.chooser-page details.format footer {
+    display: flex;
+    justify-content: space-between;
+    padding: 1em;
+}
+
+.chooser-page details.format footer label {
+    margin-left: .2em;
+}
+
+.chooser-page details.format footer button {
+    padding: .5em 1em;
+
+    background: #324C7F;
+    color: white;
+    border-radius: 3px;
+    border: none;
+}
+
+.chooser-page details.format footer button:hover {
+    cursor: pointer;
+}
+
+.chooser-page .content {
+    grid-column: 3 / 10;
+}
+
+.chooser-page #help {
+    margin-top: 4em;
+ }
+
+ .chooser-page #help details {
+    margin-bottom: 1em;
+ }
+
+ .chooser-page #help ul {
+    font-size: 1em;
+    padding: 0 1em;
+ }
+
+ .chooser-page #help ul li {
+    padding-bottom: .5em;
+ }
+
+ .chooser-page #help dl {
+    padding: 0 1em;
+ }
+
+
+@media (max-width: 705px) {
+    .chooser-page .content {
+        display: block;
+    }
+}
+
+.chooser-page .panel {
+    display: none;
+}
+
+.chooser-page .panel.expand {
+    display: initial;
+}

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/js/chooser.js
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/js/chooser.js
@@ -8,7 +8,7 @@ let rawStatePathRoutes = [
     'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc/(attribution-details)&tool=cc-by-nc',
     'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc-sa/(attribution-details)&tool=cc-by-nc-sa',
     'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc-nd/(attribution-details)&tool=cc-by-nc-nd',
-    
+
     'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/yes/share-alike/no/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by',
     'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/yes/share-alike/yes/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-sa',
     'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/no/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-nd',
@@ -22,7 +22,7 @@ let rawStatePathRoutes = [
 let state = {};
 
 // all found fieldsets
-const fieldsets = document.querySelectorAll('fieldset'); 
+const fieldsets = document.querySelectorAll('fieldset');
 
 // all found toggles
 const toggles = document.querySelectorAll('#mark-your-work footer input');
@@ -67,13 +67,13 @@ function setStatePossibilities(state) {
         });
 
         fullPath = statePath[0].replace(/[{()}]/g, '') + '/';
-    
+
         if (state.possibilities[tool] == undefined) {
             state.possibilities[tool] = [];
         }
         state.possibilities[tool].push(fullPath);
         state.possibilities[tool].push(noOptionalsPath);
-        
+
     });
 }
 
@@ -91,10 +91,10 @@ function updateStateParts(element, index, event, state) {
     state.parts[index] = element.id + '/' + event.target.value + '/';
 
     // check if checkbox, with siblings
-    if (event.target.getAttribute('type') == 'checkbox') {        
+    if (event.target.getAttribute('type') == 'checkbox') {
         let checkboxElements = element.querySelectorAll('input[type="checkbox"]');
         let checkboxes = [];
-        checkboxElements.forEach((checkbox, index) => { 
+        checkboxElements.forEach((checkbox, index) => {
             if (checkbox.checked) {
                 checkboxes[index] = checkbox.value;
             }
@@ -114,15 +114,15 @@ function updateStateParts(element, index, event, state) {
     }
 }
 
-// function to combine current tracked 
+// function to combine current tracked
 // state.parts into state.current
 function setStateCurrent(element, index,  state) {
     state.parts.forEach((element, i) => {
         if (i > index) {
-            state.parts.splice(i);  
+            state.parts.splice(i);
         }
     });
-    
+
     state.current = state.parts.join('') //.slice(0, -1);
 }
 
@@ -149,7 +149,7 @@ function setStateProps(index, state) {
 
         // set shortName
         shortName = state.props.tool.replace(/cc-/, '');
-        state.props.toolURL = 'https://creativecommons.org/licenses/'+ shortName +'/4.0/'; 
+        state.props.toolURL = 'https://creativecommons.org/licenses/'+ shortName +'/4.0/';
     }
 
     if (state.props.tool != 'unknown' ) {
@@ -174,7 +174,7 @@ function setStateProps(index, state) {
     setStatePropsAttribution(state);
 }
 
-// function to just set the attribution 
+// function to just set the attribution
 // subset of state.props (for use other places)
 function setStatePropsAttribution(state) {
 
@@ -211,9 +211,9 @@ function setStatePropsAttribution(state) {
 
 // function to reset values beyond current fieldset
 // [T]: this could potentially do with a refactor
-// check for input type, and them perform 
+// check for input type, and them perform
 // contextual resets to universal defaults
-// unchecked for radio/checkbox, noselect for 
+// unchecked for radio/checkbox, noselect for
 // selection dropdown, etc.
 function clearStepsAfterCursor(fieldsets, state) {
     fieldsets.forEach((element, index) => {
@@ -374,21 +374,21 @@ function renderMarkingFormats(state) {
 }
 
 
-// function to replace placeholders with values 
+// function to replace placeholders with values
 // for mark format constriction
 // lots of TODOs here (just for testing)
 // can use this to build out string replacement when
 // swapping in html from a <template> element
 // this will enable, controlling the markup, in markup
 // and then JS is only having to do logic replacement
-// of the token placeholders, rather than storing strings 
+// of the token placeholders, rather than storing strings
 // within the JS unnecessarily.
 
 
 // function parseTokens(name, value, str){
 //     return str.replaceAll("{{"+name+"}}", value);
 // }
-  
+
 //   const mark = 'test {{title}} {{year}} by {{author}}';
 
 //   parsedMark = parseTokens("year", "2025", mark);
@@ -400,16 +400,16 @@ function renderMarkingFormats(state) {
 
 // function to render "empty area"
 // if no valid tool from state.parts and/or state/current
-function renderEmptyPlaceholder(state) { 
+function renderEmptyPlaceholder(state) {
 
     if (state.props.tool == 'unknown' ) {
         document.querySelector('#empty').classList.remove('disable');
     }
-    
+
     else if (state.props.tool != 'unknown') {
         document.querySelector('#empty').classList.add('disable');
     }
-    
+
 }
 
 // function to render "mark your work",
@@ -417,14 +417,14 @@ function renderEmptyPlaceholder(state) {
 // if attribution details input(s) filled out
 function renderMarkYourWork(state) {
     if (state.props.tool != 'unknown' ) {
-        // load attribution details template, 
+        // load attribution details template,
         // populate from attribution text values
         document.querySelector('#mark-your-work').classList.remove('disable');
-        
+
         renderMarkingFormats(state);
 
     }
-    
+
     else if (state.props.tool == 'unknown') {
         document.querySelector('#mark-your-work').classList.add('disable');
     }
@@ -451,8 +451,8 @@ function setDefaults(applyDefaults) {
     document.querySelector('#tool-rec-details').classList.add('hide');
 }
 
-// stepper logic here for what parts of form are 
-// displayed/hidden, as state.parts and state.current 
+// stepper logic here for what parts of form are
+// displayed/hidden, as state.parts and state.current
 // are updated
 function renderSteps(applyDefaults, state) {
 
@@ -464,7 +464,7 @@ function renderSteps(applyDefaults, state) {
         });
         document.querySelector('#which-license-do-you-need').classList.toggle('disable');
         document.querySelector('#waive-your-copyright').classList.add('disable');
-            
+
     }
 
     // if visitor doesn't need help
@@ -486,7 +486,7 @@ function renderSteps(applyDefaults, state) {
         });
 
         document.querySelector('#waive-your-copyright').classList.remove('disable');
-    
+
     } else {
         document.querySelector('#waive-your-copyright').classList.add('disable');
     }
@@ -507,12 +507,12 @@ function renderSteps(applyDefaults, state) {
     if (state.parts[4] == 'allow-derivatives/no/') {
         document.querySelector('#share-alike').classList.add('disable');
     }
-    
+
 }
 
 // [T]: function to handle error state
 
-// function to watch for fieldset changes 
+// function to watch for fieldset changes
 function watchFieldsets(fieldsets, state) {
     fieldsets.forEach((element, index) => {
 
@@ -567,7 +567,7 @@ function watchMarkToggles(toggles, state) {
 }
 
 function watchMarkCopiers(copiers, state) {
-    
+
     function copyToClipboard (text) {
         let temp = document.createElement("textarea");
         document.body.appendChild(temp);
@@ -592,7 +592,7 @@ function watchMarkCopiers(copiers, state) {
 }
 
 document.addEventListener("DOMContentLoaded", (event) => {
-    // full flow logic 
+    // full flow logic
     setStateParts(state);
 
     setStatePossibilities(state);
@@ -610,11 +610,11 @@ document.addEventListener("DOMContentLoaded", (event) => {
 // rough panel expansion test
 // let expandButtons = document.querySelectorAll('button.expandPanel');
 
-// expandButtons.forEach((element, index) => { 
+// expandButtons.forEach((element, index) => {
 //     element.addEventListener("click", (event) => {
 
 //         parent = event.target.parentNode.parentNode;
 //         parent.querySelector('.panel').classList.toggle('expand');
-    
+
 //     });
 // });

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/js/chooser.js
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/chooser/js/chooser.js
@@ -1,0 +1,620 @@
+
+// all possible State Path Routes
+let rawStatePathRoutes = [
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-0/waive-your-copyright+waive+read/(attribution-details)&tool=cc-0',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by/(attribution-details)&tool=cc-by',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-sa/(attribution-details)&tool=cc-by-sa',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nd/(attribution-details)&tool=cc-by-nd',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc/(attribution-details)&tool=cc-by-nc',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc-sa/(attribution-details)&tool=cc-by-nc-sa',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc-nd/(attribution-details)&tool=cc-by-nc-nd',
+    
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/yes/share-alike/no/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/yes/share-alike/yes/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-sa',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/no/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-nd',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/no/allow-derivatives/yes/share-alike/no/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-nc',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/no/allow-derivatives/yes/share-alike/yes/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-nc-sa',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/no/allow-derivatives/no/confirmation+ownership+read+revocation/(attribution-details)&tool=cc-by-nc-nd',
+    'do-you-know-which-license-you-need/no/require-attribution/no/waive-your-copyright+waive+read/(attribution-details)&tool=cc-0'
+];
+
+// empty state obj
+let state = {};
+
+// all found fieldsets
+const fieldsets = document.querySelectorAll('fieldset'); 
+
+// all found toggles
+const toggles = document.querySelectorAll('#mark-your-work footer input');
+
+// all found copiers
+const copiers = document.querySelectorAll('#mark-your-work footer button');
+
+// empty defaults obj
+let applyDefaults = {};
+
+// set elemnts which need defaults
+// on initial page load
+applyDefaults.elements = [
+    '#require-attribution',
+    '#allow-commercial-use',
+    '#allow-derivatives',
+    '#share-alike',
+    '#waive-your-copyright',
+    '#confirmation'
+];
+
+// function to parse and build state.possibilities
+// from rawStatePathRoutes
+function setStatePossibilities(state) {
+
+    // create state possibilities from possible tools with adjoining statePaths
+    state.possibilities = [];
+    rawStatePathRoutes.forEach((path, index) => {
+
+        statePath = path.split("&");
+        statepath = statePath;
+        tool = statePath[statePath.length - 1].split("=");
+        tool = tool[1];
+
+        regEx = /\(([^)]+)\)/g;
+        optionals = statePath[0].match(regEx);
+
+        optionals.forEach ((optional) => {
+
+            noOptionalsPath = statePath[0].replace(optional,'');
+
+        });
+
+        fullPath = statePath[0].replace(/[{()}]/g, '') + '/';
+    
+        if (state.possibilities[tool] == undefined) {
+            state.possibilities[tool] = [];
+        }
+        state.possibilities[tool].push(fullPath);
+        state.possibilities[tool].push(noOptionalsPath);
+        
+    });
+}
+
+// function to establish state.parts
+function setStateParts(state) {
+    state.parts = [];
+
+    // temp defaults
+    state.parts[0] = 'do-you-know-which-license-you-need/yes/';
+    state.parts[8] = 'attribution-details/';
+}
+// function to update state.parts
+function updateStateParts(element, index, event, state) {
+
+    state.parts[index] = element.id + '/' + event.target.value + '/';
+
+    // check if checkbox, with siblings
+    if (event.target.getAttribute('type') == 'checkbox') {        
+        let checkboxElements = element.querySelectorAll('input[type="checkbox"]');
+        let checkboxes = [];
+        checkboxElements.forEach((checkbox, index) => { 
+            if (checkbox.checked) {
+                checkboxes[index] = checkbox.value;
+            }
+        });
+
+
+        let joinedCheckboxes = checkboxes.filter(Boolean).join('+');
+
+        state.parts[index] = element.id + '+' + joinedCheckboxes + '/';;
+    }
+
+    // check if text input
+    if (event.target.getAttribute('type') == 'text') {
+
+        state.parts[index] = element.id + '/';
+
+    }
+}
+
+// function to combine current tracked 
+// state.parts into state.current
+function setStateCurrent(element, index,  state) {
+    state.parts.forEach((element, i) => {
+        if (i > index) {
+            state.parts.splice(i);  
+        }
+    });
+    
+    state.current = state.parts.join('') //.slice(0, -1);
+}
+
+// function to set state.props
+// including setting state.props.tool (if valid)
+// or error
+function setStateProps(index, state) {
+
+    state.props = {};
+    state.props.tool = 'unknown';
+
+    // check and match possibilities
+    Object.keys(state.possibilities).forEach((possibility) => {
+        if(state.possibilities[possibility].includes(state.current)) {
+            state.props.tool = possibility;
+        }
+    });
+
+    // set toolFull, toolShort, toolURL
+    if (state.props.tool != 'unknown' && state.props.tool != 'cc-0' ) { // was OR, changes to AND
+
+        formattedTool = state.props.tool.replace(/-/, ' ').toUpperCase();
+        state.props.toolShort = formattedTool + ' 4.0';
+
+        // set shortName
+        shortName = state.props.tool.replace(/cc-/, '');
+        state.props.toolURL = 'https://creativecommons.org/licenses/'+ shortName +'/4.0/'; 
+    }
+
+    if (state.props.tool != 'unknown' ) {
+        //set longName
+        let tool = state.props.tool;
+        let template = document.getElementById(tool);
+        let templateContent = template.content.cloneNode(true);
+        state.props.toolLong = templateContent.querySelector('header h4').textContent;
+    }
+
+    if (state.props.tool == 'cc-0') {
+
+        state.props.toolShort = 'CC0 1.0';
+
+        // set toolFull
+        state.props.toolURL = 'https://creativecommons.org/publicdomain/zero/1.0/';
+    }
+
+    state.props.cursor = index;
+
+    state.props.attribution = [];
+    setStatePropsAttribution(state);
+}
+
+// function to just set the attribution 
+// subset of state.props (for use other places)
+function setStatePropsAttribution(state) {
+
+    if (document.querySelector('#attribution-details #title').value == '') {
+        state.props.attribution.title = document.querySelector('#attribution-details #title').placeholder.replace(/(<([^>]+)>)/gi, "");
+    } else {
+        state.props.attribution.title = document.querySelector('#attribution-details #title').value.replace(/(<([^>]+)>)/gi, "");
+    }
+
+    if (document.querySelector('#attribution-details #creator').value == '') {
+        state.props.attribution.creator = document.querySelector('#attribution-details #creator').placeholder.replace(/(<([^>]+)>)/gi, "");
+    } else {
+        state.props.attribution.creator = document.querySelector('#attribution-details #creator').value.replace(/(<([^>]+)>)/gi, "");
+    }
+
+    if (document.querySelector('#attribution-details #work-link').value == '') {
+        state.props.attribution.workLink = document.querySelector('#attribution-details #work-link').placeholder.replace(/(<([^>]+)>)/gi, "");
+    } else {
+        state.props.attribution.workLink = document.querySelector('#attribution-details #work-link').value.replace(/(<([^>]+)>)/gi, "");
+    }
+
+    if (document.querySelector('#attribution-details #creator-link').value == '') {
+        state.props.attribution.creatorLink = document.querySelector('#attribution-details #creator-link').placeholder.replace(/(<([^>]+)>)/gi, "");
+    } else {
+        state.props.attribution.creatorLink = document.querySelector('#attribution-details #creator-link').value.replace(/(<([^>]+)>)/gi, "");
+    }
+
+    if (document.querySelector('#attribution-details #work-creation-year').value == '') {
+        state.props.attribution.workCreationYear = document.querySelector('#attribution-details #work-creation-year').placeholder.replace(/(<([^>]+)>)/gi, "");
+    } else {
+        state.props.attribution.workCreationYear = document.querySelector('#attribution-details #work-creation-year').value.replace(/(<([^>]+)>)/gi, "");
+    }
+}
+
+// function to reset values beyond current fieldset
+// [T]: this could potentially do with a refactor
+// check for input type, and them perform 
+// contextual resets to universal defaults
+// unchecked for radio/checkbox, noselect for 
+// selection dropdown, etc.
+function clearStepsAfterCursor(fieldsets, state) {
+    fieldsets.forEach((element, index) => {
+        if (index > state.props.cursor) {
+
+            if (index == 1) {
+                element.querySelector("#tool").value = "noselect";
+            }
+
+            if (index != 1 | index != 8) {
+
+                let inputs = element.querySelectorAll('input');
+                inputs.forEach((input, i) => {
+                    input.checked = false;
+                });
+            }
+        }
+    });
+}
+
+// function to render "tool recommendation",
+// if valid tool from state.parts and/or state.current
+function renderToolRec(state) {
+
+    if (state.props.tool != 'unknown' ) {
+        document.querySelector('#tool-recommendation').classList.remove('disable');
+
+        let tool = state.props.tool;
+        let template = document.getElementById(tool);
+        let templateContent = template.content.cloneNode(true);
+        document.querySelector('#tool-recommendation .tool').textContent = '';
+        document.querySelector('#tool-recommendation .tool').appendChild(templateContent);
+    }
+    else if (state.props.tool == 'unknown') {
+        document.querySelector('#tool-recommendation').classList.add('disable');
+        document.querySelector('#tool-recommendation .tool').textContent = '';
+    }
+
+}
+
+// render specifically the mark formats subsections
+function renderMarkingFormats(state) {
+
+    if (state.props.tool != 'unknown' ) {}
+
+    setStatePropsAttribution(state);
+
+    let attribution = state.props.attribution;
+
+    let type = "license";
+    let typeAsVerb = "licensed under";
+    let copyright = ' © ' + attribution.workCreationYear;
+    if (state.props.tool == 'cc-0') {
+        type = "mark";
+        typeAsVerb = "marked";
+        copyright = '';
+    }
+
+    // set contents of plain text mark
+    // [T]: reverse use of <template> since it has limits on tokenization capacity, even if
+    // it allows more dev readability.
+    let template = document.getElementById('plain-text');
+    let templateContent = template.content.cloneNode(true);
+    document.querySelector('#mark-your-work .plain-text.mark').textContent = '';
+
+    function parseTokens(name, value, str){
+        return str.replaceAll("{{"+name+"}}", value);
+    }
+
+    let markProps = {};
+    markProps.title = attribution.title;
+    markProps.year = attribution.workCreationYear;
+    markProps.creator = attribution.creator;
+    markProps.type = type;
+    markProps.typeAsVerb = typeAsVerb;
+    markProps.toolShort = state.props.toolShort;
+    markProps.toolLong = state.props.toolLong;
+    markProps.toolURL = state.props.toolURL;
+    markProps.copyright = copyright;
+
+    // set contents of plain text mark
+    plainTextFullName = document.querySelector('#plain-text-full-name').checked;
+
+    if (plainTextFullName == true) {
+        markProps.toolName = state.props.toolLong;
+
+    } else {
+        markProps.toolName = state.props.toolShort;
+    }
+
+    // [T]: could carve out separate sections for different mark formats here
+    // only handles plain text at the moment
+    for (const [key, value] of Object.entries(markProps)) {
+        templateContent.textContent = parseTokens(key, value, templateContent.textContent);
+    }
+    document.querySelector('#mark-your-work .plain-text.mark').appendChild(templateContent);
+
+    // set contents of rich text mark
+    let ccSVG = '<img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;">';
+    let bySVG = '<img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;">';
+    let saSVG = '<img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;">';
+    let ncSVG = '<img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;">';
+    let ndSVG = '<img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;">';
+    let zeroSVG = '<img src="https://mirrors.creativecommons.org/presskit/icons/zero.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;">';
+
+    const currentTool = state.props.tool;
+    switch (currentTool) {
+        case 'cc-0':
+            ccIconSet = ccSVG + zeroSVG;
+            break;
+        case 'cc-by':
+            ccIconSet = ccSVG + bySVG;
+            break;
+        case 'cc-by-sa':
+            ccIconSet = ccSVG + bySVG + saSVG;
+            break;
+        case 'cc-by-nd':
+            ccIconSet = ccSVG + bySVG + ndSVG;
+            break;
+        case 'cc-by-nc':
+            ccIconSet = ccSVG + bySVG + ncSVG;
+            break;
+        case 'cc-by-nc-sa':
+            ccIconSet = ccSVG + bySVG + ncSVG + saSVG;
+            break;
+        case 'cc-by-nc-nd':
+            ccIconSet = ccSVG + bySVG + ncSVG + ndSVG;
+            break;
+        default:
+            currentTool = '';
+    }
+
+    richTextFullName = document.querySelector('#rich-text-full-name').checked;
+
+    if (richTextFullName == true) {
+        markProps.toolName = state.props.toolLong;
+
+    } else {
+        markProps.toolName = state.props.toolShort;
+    }
+
+    let richTextMark = '<a href="' + attribution.workLink + '">' + attribution.title + '</a>' + copyright + ' by ' + '<a href="' + attribution.creatorLink + '">' + attribution.creator + '</a>' + ' is ' + typeAsVerb  + ' ' + '<a href="' + state.props.toolURL + '">' + markProps.toolName + '</a>' + ccIconSet;
+    document.querySelector('#mark-your-work .rich-text.mark').innerHTML = richTextMark;
+
+
+    // set contents of HTML mark
+    htmlFullName = document.querySelector('#html-full-name').checked;
+
+    if (htmlFullName == true) {
+        markProps.toolName = state.props.toolLong;
+
+    } else {
+        markProps.toolName = state.props.toolShort;
+    }
+    //defaultHTML = '<p xmlns:cc="http://creativecommons.org/ns#">This work is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="license noopener noreferrer">CC BY-SA 4.0<img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt=""></a></p>';
+    let htmlMark = '<a href="' + attribution.workLink + '">' + attribution.title + '</a>' + copyright + ' by ' + '<a href="' + attribution.creatorLink + '">' + attribution.creator + '</a>' + ' is ' + typeAsVerb  + ' ' + '<a href="' + state.props.toolURL + '">' + markProps.toolName + '</a>' + ccIconSet;
+    document.querySelector('#mark-your-work .html.mark').innerHTML = htmlMark;
+}
+
+
+// function to replace placeholders with values 
+// for mark format constriction
+// lots of TODOs here (just for testing)
+// can use this to build out string replacement when
+// swapping in html from a <template> element
+// this will enable, controlling the markup, in markup
+// and then JS is only having to do logic replacement
+// of the token placeholders, rather than storing strings 
+// within the JS unnecessarily.
+
+
+// function parseTokens(name, value, str){
+//     return str.replaceAll("{{"+name+"}}", value);
+// }
+  
+//   const mark = 'test {{title}} {{year}} by {{author}}';
+
+//   parsedMark = parseTokens("year", "2025", mark);
+//   parsedMark = parseTokens("title", "cool work", parsedMark);
+//   parsedMark = parseTokens("author", "jane mayer", parsedMark);
+//   console.log(parsedMark);
+
+
+
+// function to render "empty area"
+// if no valid tool from state.parts and/or state/current
+function renderEmptyPlaceholder(state) { 
+
+    if (state.props.tool == 'unknown' ) {
+        document.querySelector('#empty').classList.remove('disable');
+    }
+    
+    else if (state.props.tool != 'unknown') {
+        document.querySelector('#empty').classList.add('disable');
+    }
+    
+}
+
+// function to render "mark your work",
+// if valid tool from state.parts and/or state.current
+// if attribution details input(s) filled out
+function renderMarkYourWork(state) {
+    if (state.props.tool != 'unknown' ) {
+        // load attribution details template, 
+        // populate from attribution text values
+        document.querySelector('#mark-your-work').classList.remove('disable');
+        
+        renderMarkingFormats(state);
+
+    }
+    
+    else if (state.props.tool == 'unknown') {
+        document.querySelector('#mark-your-work').classList.add('disable');
+    }
+
+}
+
+// function to set default UX states on Steps
+// set default visibly disabled pathways
+
+function setDefaults(applyDefaults) {
+
+    applyDefaults.elements.forEach((element) => {
+        document.querySelector(element).classList.toggle('disable');
+    });
+
+    if (state.parts[0] == 'do-you-know-which-license-you-need/yes/' ) {
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.add('disable');
+        });
+    }
+
+    document.querySelector('#tool-recommendation').classList.add('disable');
+    document.querySelector('#mark-your-work').classList.add('disable');
+    document.querySelector('#tool-rec-details').classList.add('hide');
+}
+
+// stepper logic here for what parts of form are 
+// displayed/hidden, as state.parts and state.current 
+// are updated
+function renderSteps(applyDefaults, state) {
+
+    // check if visitor needs help, start help pathways
+    if (state.current == 'do-you-know-which-license-you-need/no/' ) {
+
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.remove('disable');
+        });
+        document.querySelector('#which-license-do-you-need').classList.toggle('disable');
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+            
+    }
+
+    // if visitor doesn't need help
+    if (state.current == 'do-you-know-which-license-you-need/yes/' ) {
+
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.add('disable');
+        });
+        document.querySelector('#which-license-do-you-need').classList.toggle('disable');
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+
+    }
+
+    // check if cc0
+    if (state.parts[2] == 'require-attribution/no/' || state.parts[1] == 'which-license-do-you-need/cc-0/' ) {
+
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.add('disable');
+        });
+
+        document.querySelector('#waive-your-copyright').classList.remove('disable');
+    
+    } else {
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+    }
+    if (state.parts[2] == 'require-attribution/no/') {
+        document.querySelector('#require-attribution').classList.remove('disable');
+    }
+
+    // walk away from cc-0, reset attribution choice point
+    if (state.parts[2] == 'require-attribution/yes/') {
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.remove('disable');
+        });
+        document.querySelector('#require-attribution').classList.remove('disable');
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+    }
+
+    // tie SA to ND choice
+    if (state.parts[4] == 'allow-derivatives/no/') {
+        document.querySelector('#share-alike').classList.add('disable');
+    }
+    
+}
+
+// [T]: function to handle error state
+
+// function to watch for fieldset changes 
+function watchFieldsets(fieldsets, state) {
+    fieldsets.forEach((element, index) => {
+
+        // [T]: set defaults here first in state.parts dynamically
+
+        element.addEventListener("change", (event) => {
+
+            updateStateParts(element, index, event, state);
+
+            setStateCurrent(element, index, state);
+
+            setStateProps(index, state);
+
+            // [T]: also reset values beyond current changed fieldset to nothing each time
+            clearStepsAfterCursor(fieldsets, state);
+
+            renderSteps(applyDefaults, state);
+
+            renderEmptyPlaceholder(state);
+
+            renderToolRec(state);
+
+            renderMarkYourWork(state);
+
+        });
+
+    });
+}
+
+function watchAttributionDetails(fieldsets, state) {
+
+    let textFields = fieldsets[8].querySelectorAll('input');
+
+    textFields.forEach((element, index) => {
+
+        element.addEventListener("keyup", (event) => {
+            renderMarkingFormats(state);
+        });
+
+    });
+}
+
+function watchMarkToggles(toggles, state) {
+
+    toggles.forEach((element, index) => {
+
+        element.addEventListener("click", (event) => {
+            renderMarkingFormats(state);
+        });
+
+    });
+}
+
+function watchMarkCopiers(copiers, state) {
+    
+    function copyToClipboard (text) {
+        let temp = document.createElement("textarea");
+        document.body.appendChild(temp);
+        temp.value = text;
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+    }
+
+    copiers.forEach((element, index) => {
+
+        element.addEventListener("click", (event) => {
+
+            if (element.parentNode.parentNode.querySelector('.mark').value != null) {
+                copyToClipboard(element.parentNode.parentNode.querySelector('.mark').value);
+            } else {
+                copyToClipboard(element.parentNode.parentNode.querySelector('.mark').innerHTML);
+            }
+        });
+
+    });
+}
+
+document.addEventListener("DOMContentLoaded", (event) => {
+    // full flow logic 
+    setStateParts(state);
+
+    setStatePossibilities(state);
+
+    setDefaults(applyDefaults);
+
+    setStateProps(0, state);
+
+    watchFieldsets(fieldsets, state);
+    watchAttributionDetails(fieldsets, state);
+    watchMarkToggles(toggles, state);
+    watchMarkCopiers(copiers, state);
+});
+
+// rough panel expansion test
+// let expandButtons = document.querySelectorAll('button.expandPanel');
+
+// expandButtons.forEach((element, index) => { 
+//     element.addEventListener("click", (event) => {
+
+//         parent = event.target.parentNode.parentNode;
+//         parent.querySelector('.panel').classList.toggle('expand');
+    
+//     });
+// });

--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
@@ -3,7 +3,7 @@ Theme Name: CC Vocabulary Theme
 Author: the Creative Commons team; possumbilities, Timid Robot
 Author URI: https://opensource.creativecommons.org/
 Description: Theme based on the Vocabulary Design System
-Version: 1.10
+Version: 1.11.1
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.0
@@ -12,6 +12,7 @@ License URI: https://github.com/creativecommons/vocabulary-theme/blob/main/LICEN
 */
 
 @import 'vocabulary/css/vocabulary.css' layer(vocabulary);
+@import 'chooser/css/chooser.css' layer(chooser);
 
 
 /* WordPress specific rules */
@@ -914,6 +915,10 @@ main nav.pagination ul li span.current {
 
 main .content ul, main .content ol {
     line-height: 150%;
+}
+
+.chooser-page main .content ul, .chooser-page main .content ol {
+  line-height: 100%;
 }
 
 /* Classic Editor TinyMCE WYSIWYG editor image alignment  */

--- a/dev/copy_theme.sh
+++ b/dev/copy_theme.sh
@@ -48,6 +48,7 @@ copy_vocabulary_theme_files() {
     print_var REPO_DIR
     print_var STATIC_THEME_DIR | sed -e"s#${REPO_DIR}#.#"
     {
+        cp -av "${THEME_DIR}/src/chooser" "${STATIC_THEME_DIR}/"
         cp -v "${THEME_DIR}/src/style.css" "${STATIC_THEME_DIR}/"
         cp -av "${THEME_DIR}/src/vocabulary" "${STATIC_THEME_DIR}/"
     } | sed \


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #510

## Description
App: update standalone dev env `vocabulary-theme` to `v1.11.1`
- Update `dev/copy_theme.sh` to include chooser
- Update standalone dev env `vocabulary-theme` to `v1.11.1`

Also see related Data pull request (PR):
- creativecommons/cc-legal-tools-data/pull/243

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
### Unit tests and coverage
command:
```shell
./dev/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1800      0    590      0  100.00%

20 files skipped due to complete coverage.
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
