### PR TITLE
App: update dev copy of vocabulary-theme to 1.15 (1eaf45a)

### DIFF
--- a/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
+++ b/cc_legal_tools/static/wp-content/themes/vocabulary-theme/style.css
@@ -3,7 +3,7 @@ Theme Name: CC Vocabulary Theme
 Author: the Creative Commons team; possumbilities, Timid Robot
 Author URI: https://opensource.creativecommons.org/
 Description: Theme based on the Vocabulary Design System
-Version: 1.14
+Version: 1.15
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.0


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #546
- Fixes #554 

## Description
App: update dev copy of vocabulary-theme to 1.15 (1eaf45a)
- (Most of the recent changes to [vocabulary-theme](https://github.com/creativecommons/vocabulary-theme/) have targeted the chooser and WordPress and are not included here)

Also see related Data pull request (PR):
- creativecommons/cc-legal-tools-data/pull/275

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
