### PR TITLE
App: corrects display of sidebar, stops overflow, binds `main` to fixed width on large viewports

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -1,9 +1,12 @@
-@import "/wp-content/themes/vocabulary-theme/style.css" layer(vocabulary-theme);
 @import "/wp-content/themes/vocabulary-theme/pidgin/css/pidgin.css" layer(vocabulary);
+@import "/wp-content/themes/vocabulary-theme/style.css" layer(vocabulary);
+
 
 
 body .locale {
   display: flex;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 }
 
 body.legal-tools main {
@@ -108,6 +111,14 @@ main > header > span.alt-titles > span.tool-icons > span.cc-icon > svg {
   margin-left: 4.1rem;
   padding: 1em;
   height: fit-content;
+
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  word-break: break-word;
+
+  /* Adds a hyphen where the word breaks, if supported (No Blink) */
+  hyphens: auto;
 }
 .cc-legal-tools main > aside a {
   --underline-background-color: var(--vocabulary-brand-color-soft-gold);
@@ -289,3 +300,13 @@ main > aside > nav ul > li {
     display: none;
   }
 }
+
+@media (max-width: 1028px) {
+    main {
+      display: block;
+      width: 100%;
+      overflow: hidden;
+      padding: 0 var(--vocabulary-page-edges-space);
+      box-sizing: border-box;
+    }
+  }

--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -109,7 +109,6 @@ main > header > span.alt-titles > span.tool-icons > span.cc-icon > svg {
 /* right nav */
 .cc-legal-tools main > aside {
   margin-left: 4.1rem;
-  padding: 1em;
   height: fit-content;
 
   overflow-wrap: break-word;
@@ -126,6 +125,7 @@ main > header > span.alt-titles > span.tool-icons > span.cc-icon > svg {
 main > aside > nav ul > li {
   /* TODO: resolve with vocabulary-theme */
   font-size: 1rem;
+  padding-right: 1em;
 }
 
 /* content */


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
App: corrects display of sidebar, stops overflow, binds main to fixed width on large viewports:
- corrects cascade order of stylesheet `@import`s
- corrects `@layer` namespacing for stylesheets
- corrects fixed width at large viewport sizes
- adds appropriate styling for large viewports to `.locale` div
- forces long hyperlinks to linebreak in `.sidebar`
- forces `main` to break to single column sooner, so `.sidebar` is not crunched and unreadable on smaller viewports
- `.sidebar` aligns properly with top of content
- adjusts padding on `.sidebar` internally to fit better
- also see related Data pull request (PR):
  - creativecommons/cc-legal-tools-data/pull/283

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
