### PR TITLE
Add Markdown and plain text render support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ application manages over 30,000 documents.
 ### Not the live site
 
 This project is not intended to serve the legal tools directly. Instead, a
-command line tool can be used to save all the rendered HTML, Markdown, and
-plain text, and RDF/XML pages as files. Then those files are used as part of the
+command line tool can be used to save all the rendered HTML, Markdown, plain
+text, and RDF/XML pages as files. Then those files are used as part of the
 CreativeCommons.org site (served as static files).
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ application manages over 30,000 documents.
 
 This project is not intended to serve the legal tools directly. Instead, a
 command line tool can be used to save all the rendered HTML, Markdown, and
-RDF/XML pages as files. Then those files are used as part of the
+plain text, and RDF/XML pages as files. Then those files are used as part of the
 CreativeCommons.org site (served as static files).
 
 
@@ -214,9 +214,9 @@ Repository](#data-repository), above).
 
 #### Static Files Process
 
-This process will write the generated HTML, Markdown, and RDF/XML files in the
-cc-legal-tools-data clone directory under `docs/`. By default it doesn't
-commit any changes.
+This process will write the generated HTML, Markdown, plain text, and RDF/XML
+files in the cc-legal-tools-data clone directory under `docs/`. By default it
+doesn't commit any changes.
 
 1. Ensure the [Data Repository](#data-repository), above, is in place
 2. Ensure [Docker Compose Setup](#docker-compose-setup), above, is complete
@@ -238,16 +238,15 @@ commit any changes.
         INFO 17:36:31 Distilling index.rdf
         INFO 17:36:33 Distilling images.rdf
         INFO 17:36:33 Distilling ns.html
-        INFO 17:36:33 Copying plaintext legal code
         INFO 17:36:33 Distilling dev index
         INFO 17:36:34 Distilling lists
-        INFO 17:36:36 Distilling Licenses 4.0 deed/legal code HTML and legal code Markdown/RDF/XML
-        INFO 17:36:41 Distilling Licenses 3.0 deed/legal code HTML and legal code Markdown/RDF/XML
-        INFO 17:37:23 Distilling Licenses 2.5 deed/legal code HTML and legal code Markdown/RDF/XML
-        INFO 17:37:50 Distilling Licenses 2.1 deed/legal code HTML and legal code Markdown/RDF/XML
-        INFO 17:37:54 Distilling Licenses 2.0 deed/legal code HTML and legal code Markdown/RDF/XML
-        INFO 17:38:14 Distilling Licenses 1.0 deed/legal code HTML and legal code Markdown/RDF/XML
-        INFO 17:38:20 Distilling Public Domain all deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:36:36 Distilling Licenses 4.0 deed/legal code HTML and legal code Markdown/plain text/RDF/XML
+        INFO 17:36:41 Distilling Licenses 3.0 deed/legal code HTML and legal code Markdown/plain text/RDF/XML
+        INFO 17:37:23 Distilling Licenses 2.5 deed/legal code HTML and legal code Markdown/plain text/RDF/XML
+        INFO 17:37:50 Distilling Licenses 2.1 deed/legal code HTML and legal code Markdown/plain text/RDF/XML
+        INFO 17:37:54 Distilling Licenses 2.0 deed/legal code HTML and legal code Markdown/plain text/RDF/XML
+        INFO 17:38:14 Distilling Licenses 1.0 deed/legal code HTML and legal code Markdown/plain text/RDF/XML
+        INFO 17:38:20 Distilling Public Domain all deed/legal code HTML and legal code Markdown/plain text/RDF/XML
         INFO 17:38:21 Writing Apache2 redirects configuration
         ```
        - (note that the laptop environment and docker environment had different
@@ -261,6 +260,7 @@ publishing a specific subset:
 ./bin/publish.sh --filter-apache-redirects
 ./bin/publish.sh --filter-license-html 4.0
 ./bin/publish.sh --filter-license-markdown 4.0
+./bin/publish.sh --filter-license-text 4.0
 ./bin/publish.sh --filter-rdf-xml
 ```
 
@@ -270,6 +270,7 @@ The same filters are available as short options:
 ./bin/publish.sh --fa
 ./bin/publish.sh --fl 4.0
 ./bin/publish.sh --fm 4.0
+./bin/publish.sh --ft 4.0
 ./bin/publish.sh --fr
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ application manages over 30,000 documents.
 ### Not the live site
 
 This project is not intended to serve the legal tools directly. Instead, a
-command line tool can be used to save all the rendered HTML and RDF/XML pages
-as files. Then those files are used as part of the CreativeCommons.org
-site (served as static files).
+command line tool can be used to save all the rendered HTML, Markdown, and
+RDF/XML pages as files. Then those files are used as part of the
+CreativeCommons.org site (served as static files).
 
 
 ## Setup and Usage
@@ -214,8 +214,9 @@ Repository](#data-repository), above).
 
 #### Static Files Process
 
-This process will write the HTML files in the cc-legal-tools-data clone
-directory under `docs/`. By default it doesn't commit any changes.
+This process will write the generated HTML, Markdown, and RDF/XML files in the
+cc-legal-tools-data clone directory under `docs/`. By default it doesn't
+commit any changes.
 
 1. Ensure the [Data Repository](#data-repository), above, is in place
 2. Ensure [Docker Compose Setup](#docker-compose-setup), above, is complete
@@ -240,17 +241,37 @@ directory under `docs/`. By default it doesn't commit any changes.
         INFO 17:36:33 Copying plaintext legal code
         INFO 17:36:33 Distilling dev index
         INFO 17:36:34 Distilling lists
-        INFO 17:36:36 Distilling Licenses 4.0 deed HTML, legal code HTML, and RDF/XML
-        INFO 17:36:41 Distilling Licenses 3.0 deed HTML, legal code HTML, and RDF/XML
-        INFO 17:37:23 Distilling Licenses 2.5 deed HTML, legal code HTML, and RDF/XML
-        INFO 17:37:50 Distilling Licenses 2.1 deed HTML, legal code HTML, and RDF/XML
-        INFO 17:37:54 Distilling Licenses 2.0 deed HTML, legal code HTML, and RDF/XML
-        INFO 17:38:14 Distilling Licenses 1.0 deed HTML, legal code HTML, and RDF/XML
-        INFO 17:38:20 Distilling Public Domain all deed HTML, legal code HTML, and RDF/XML
+        INFO 17:36:36 Distilling Licenses 4.0 deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:36:41 Distilling Licenses 3.0 deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:37:23 Distilling Licenses 2.5 deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:37:50 Distilling Licenses 2.1 deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:37:54 Distilling Licenses 2.0 deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:38:14 Distilling Licenses 1.0 deed/legal code HTML and legal code Markdown/RDF/XML
+        INFO 17:38:20 Distilling Public Domain all deed/legal code HTML and legal code Markdown/RDF/XML
         INFO 17:38:21 Writing Apache2 redirects configuration
         ```
        - (note that the laptop environment and docker environment had different
          timezones, CEST and UTC)
+
+`./bin/publish.sh` publishes all supported static output by default. The
+following mutually exclusive filter options can be used while developing or
+publishing a specific subset:
+
+```shell
+./bin/publish.sh --filter-apache-redirects
+./bin/publish.sh --filter-license-html 4.0
+./bin/publish.sh --filter-license-markdown 4.0
+./bin/publish.sh --filter-rdf-xml
+```
+
+The same filters are available as short options:
+
+```shell
+./bin/publish.sh --fa
+./bin/publish.sh --fl 4.0
+./bin/publish.sh --fm 4.0
+./bin/publish.sh --fr
+```
 
 
 #### Publishing Changes to Git Repo

--- a/legal_tools/link_utils.py
+++ b/legal_tools/link_utils.py
@@ -7,6 +7,10 @@ LEGAL_CODE_LINK_BASE_URL = "https://creativecommons.org"
 _DOMAIN_LIKE_URL_RE = re.compile(
     r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?(?=[/?#]|$)"
 )
+_EMAIL_LIKE_URL_RE = re.compile(
+    r"^[^\s@]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
+)
+_MARKDOWN_LINK_DESTINATION_RE = re.compile(r"[\s()<>]")
 
 
 def absolute_link_url(href, base_url=LEGAL_CODE_LINK_BASE_URL):
@@ -26,6 +30,64 @@ def absolute_link_url(href, base_url=LEGAL_CODE_LINK_BASE_URL):
     return f"{_base_origin(base_url)}/{href}"
 
 
+def display_link_url(href):
+    href = (href or "").strip()
+    if not href or href.startswith("#"):
+        return ""
+    return display_url(href)
+
+
+def display_link_label_url(label):
+    label = label.strip().rstrip(".!?")
+    if not looks_like_url(label):
+        return ""
+    return display_url(label)
+
+
+def display_url(value):
+    value = value.strip()
+    if not value:
+        return ""
+    if value.lower().startswith("mailto:"):
+        return _strip_mailto_url(value)
+    if _EMAIL_LIKE_URL_RE.match(value):
+        return value
+
+    normalized = absolute_link_url(value)
+    parts = urlsplit(normalized)
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        return _strip_url_parts(value)
+
+    path = parts.path or ""
+    display_value = f"{parts.netloc}{path}"
+    return display_value.rstrip("/") or parts.netloc
+
+
+def looks_like_url(value):
+    return (
+        value.startswith(("http://", "https://", "//", "/", "mailto:"))
+        or bool(_DOMAIN_LIKE_URL_RE.match(value))
+        or bool(_EMAIL_LIKE_URL_RE.match(value))
+    )
+
+
+def markdown_link(label, href):
+    label = _escape_markdown_link_label(label)
+    destination = markdown_link_destination(href)
+    return f"[{label}]({destination})"
+
+
+def markdown_link_destination(href):
+    destination = absolute_link_url(href)
+    if _MARKDOWN_LINK_DESTINATION_RE.search(destination):
+        destination = destination.replace("\\", "%5C")
+        destination = destination.replace("<", "%3C")
+        destination = destination.replace(">", "%3E")
+        destination = destination.replace("\n", "%0A")
+        return f"<{destination}>"
+    return destination
+
+
 def _base_scheme(base_url):
     return urlsplit(base_url).scheme or "https"
 
@@ -33,3 +95,17 @@ def _base_scheme(base_url):
 def _base_origin(base_url):
     parts = urlsplit(base_url)
     return f"{parts.scheme}://{parts.netloc}"
+
+
+def _escape_markdown_link_label(label):
+    label = label.replace("\\", "\\\\")
+    label = label.replace("[", "\\[")
+    return label.replace("]", "\\]")
+
+
+def _strip_mailto_url(value):
+    return value[7:].split("?", 1)[0].split("#", 1)[0].strip()
+
+
+def _strip_url_parts(value):
+    return value.split("?", 1)[0].split("#", 1)[0]

--- a/legal_tools/link_utils.py
+++ b/legal_tools/link_utils.py
@@ -1,0 +1,35 @@
+# Standard library
+import re
+from urllib.parse import urlsplit
+
+LEGAL_CODE_LINK_BASE_URL = "https://creativecommons.org"
+
+_DOMAIN_LIKE_URL_RE = re.compile(
+    r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?(?=[/?#]|$)"
+)
+
+
+def absolute_link_url(href, base_url=LEGAL_CODE_LINK_BASE_URL):
+    href = (href or "").strip()
+    if not href or href.startswith("#"):
+        return href
+    if href.startswith("//"):
+        return f"{_base_scheme(base_url)}:{href}"
+    if _DOMAIN_LIKE_URL_RE.match(href):
+        return f"{_base_scheme(base_url)}://{href}"
+
+    parts = urlsplit(href)
+    if parts.scheme:
+        return href
+    if href.startswith("/"):
+        return f"{_base_origin(base_url)}{href}"
+    return f"{_base_origin(base_url)}/{href}"
+
+
+def _base_scheme(base_url):
+    return urlsplit(base_url).scheme or "https"
+
+
+def _base_origin(base_url):
+    parts = urlsplit(base_url)
+    return f"{parts.scheme}://{parts.netloc}"

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -114,6 +114,19 @@ def save_legal_code(output_dir, legal_code, opt_filter_apache_redirects):
     return legal_code.get_redirect_pairs()
 
 
+def save_legal_code_markdown(output_dir, legal_code):
+    # Function is at top level of module so that it can be pickled by
+    # multiprocessing.
+    relpath = legal_code.get_markdown_publish_files()
+    if relpath:
+        # Deed-only tools will not return a legal code Markdown relpath
+        save_url_as_static_file(
+            output_dir,
+            url=f"{legal_code.legal_code_url}.md",
+            relpath=relpath,
+        )
+
+
 def save_rdf(output_dir, tool):
     # Function is at top level of module so that it can be pickled by
     # multiprocessing.
@@ -157,6 +170,15 @@ class Command(BaseCommand):
             choices=[1.0, 2.0, 2.1, 2.5, 3.0, 4.0],
             help="Only distill HTML files for specified license version",
             dest="filter_license_html",
+        )
+        filter_args.add_argument(
+            "--fm",
+            "--filter-license-markdown",
+            action="store",
+            type=float,
+            choices=[1.0, 2.0, 2.1, 2.5, 3.0, 4.0],
+            help="Only distill Markdown files for specified license version",
+            dest="filter_license_markdown",
         )
         filter_args.add_argument(
             "--fr",
@@ -392,14 +414,19 @@ class Command(BaseCommand):
                 if group != f"Licenses {options['filter_license_html']}":
                     continue
                 LOG.info(f"Distilling {group} deed/legal code HTML")
+            elif options["filter_license_markdown"]:
+                if group != f"Licenses {options['filter_license_markdown']}":
+                    continue
+                LOG.info(f"Distilling {group} legal code Markdown")
             elif options["filter_rdfxml"]:
                 LOG.info(f"Distilling {group} legal code RDF/XML")
             else:
                 LOG.info(
                     f"Distilling {group} deed/legal code HTML and legal code"
-                    " RDF/XML"
+                    " Markdown/RDF/XML"
                 )
             legal_code_arguments = []
+            markdown_arguments = []
             deed_arguments = []
             rdf_arguments = []
             for legal_code in legal_codes[group]:
@@ -411,6 +438,7 @@ class Command(BaseCommand):
                         options["filter_apache_redirects"],
                     )
                 )
+                markdown_arguments.append((output_dir, legal_code))
             for tool in tools:
                 for language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
                     deed_arguments.append(
@@ -435,15 +463,24 @@ class Command(BaseCommand):
                     )
 
             if not options["filter_rdfxml"]:
-                redirect_pairs_data += self.pool.starmap(
-                    save_deed, deed_arguments
-                )
-                redirect_pairs_data += self.pool.starmap(
-                    save_legal_code, legal_code_arguments
-                )
+                if not options["filter_license_markdown"]:
+                    redirect_pairs_data += self.pool.starmap(
+                        save_deed, deed_arguments
+                    )
+                    redirect_pairs_data += self.pool.starmap(
+                        save_legal_code, legal_code_arguments
+                    )
+                if not (
+                    options["filter_apache_redirects"]
+                    or options["filter_license_html"]
+                ):
+                    self.pool.starmap(
+                        save_legal_code_markdown, markdown_arguments
+                    )
             if (
                 not options["filter_apache_redirects"]
                 and not options["filter_license_html"]
+                and not options["filter_license_markdown"]
             ):
                 self.pool.starmap(save_rdf, rdf_arguments)
 
@@ -612,6 +649,9 @@ class Command(BaseCommand):
             options["run"]["pool_distill_legal_tools"] = True
         # Filter licenses HTML
         elif options["filter_license_html"]:
+            options["run"]["pool_distill_legal_tools"] = True
+        # Filter licenses Markdown
+        elif options["filter_license_markdown"]:
             options["run"]["pool_distill_legal_tools"] = True
         # Filter RDF/XML
         elif options["filter_rdfxml"]:

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -194,6 +194,15 @@ class Command(BaseCommand):
             dest="filter_license_markdown",
         )
         filter_args.add_argument(
+            "--ft",
+            "--filter-license-text",
+            action="store",
+            type=float,
+            choices=FILTER_LICENSE_VERSION_CHOICES,
+            help="Only distill plain text files for specified license version",
+            dest="filter_license_text",
+        )
+        filter_args.add_argument(
             "--fr",
             "--filter-rdf-xml",
             action="store_true",
@@ -398,6 +407,10 @@ class Command(BaseCommand):
                 if group != f"Licenses {options['filter_license_markdown']}":
                     continue
                 LOG.info(f"Distilling {group} legal code Markdown")
+            elif options["filter_license_text"]:
+                if group != f"Licenses {options['filter_license_text']}":
+                    continue
+                LOG.info(f"Distilling {group} legal code plain text")
             elif options["filter_rdfxml"]:
                 LOG.info(f"Distilling {group} legal code RDF/XML")
             else:
@@ -445,7 +458,10 @@ class Command(BaseCommand):
                     )
 
             if not options["filter_rdfxml"]:
-                if not options["filter_license_markdown"]:
+                if not (
+                    options["filter_license_markdown"]
+                    or options["filter_license_text"]
+                ):
                     redirect_pairs_data += self.pool.starmap(
                         save_deed, deed_arguments
                     )
@@ -455,6 +471,7 @@ class Command(BaseCommand):
                 if not (
                     options["filter_apache_redirects"]
                     or options["filter_license_html"]
+                    or options["filter_license_text"]
                 ):
                     self.pool.starmap(
                         save_legal_code_markdown, markdown_arguments
@@ -471,6 +488,7 @@ class Command(BaseCommand):
                 not options["filter_apache_redirects"]
                 and not options["filter_license_html"]
                 and not options["filter_license_markdown"]
+                and not options["filter_license_text"]
             ):
                 self.pool.starmap(save_rdf, rdf_arguments)
 
@@ -641,6 +659,9 @@ class Command(BaseCommand):
             options["run"]["pool_distill_legal_tools"] = True
         # Filter licenses Markdown
         elif options["filter_license_markdown"]:
+            options["run"]["pool_distill_legal_tools"] = True
+        # Filter licenses plain text
+        elif options["filter_license_text"]:
             options["run"]["pool_distill_legal_tools"] = True
         # Filter RDF/XML
         elif options["filter_rdfxml"]:

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -7,7 +7,7 @@ from copy import copy
 from multiprocessing import Pool
 from pathlib import Path
 from pprint import pprint
-from shutil import copyfile, copytree, rmtree
+from shutil import copytree, rmtree
 
 # Third-party
 from django.conf import settings
@@ -124,6 +124,18 @@ def save_legal_code_markdown(output_dir, legal_code):
         save_url_as_static_file(
             output_dir,
             url=f"{legal_code.legal_code_url}.md",
+            relpath=relpath,
+        )
+
+
+def save_legal_code_plaintext(output_dir, legal_code):
+    # Function is at top level of module so that it can be pickled by
+    # multiprocessing.
+    relpath = legal_code.get_plaintext_publish_file()
+    if relpath:
+        save_url_as_static_file(
+            output_dir,
+            url=f"{legal_code.legal_code_url}.txt",
             relpath=relpath,
         )
 
@@ -330,39 +342,6 @@ class Command(BaseCommand):
             Path(symlink_path).symlink_to(Path(symlink_dest))
             LOG.debug(f"   ^{symlink}")
 
-    def copy_legal_code_plaintext(self):
-        if not self.options["run"]["copy_legal_code_plaintext"]:
-            return
-        hostname = socket.gethostname()
-        legacy_dir = self.legacy_dir
-        output_dir = self.output_dir
-        plaintext_dir = os.path.join(legacy_dir, "legalcode")
-        plaintext_files = [
-            text_file
-            for text_file in os.listdir(plaintext_dir)
-            if (
-                os.path.isfile(os.path.join(plaintext_dir, text_file))
-                and text_file.endswith(".txt")
-            )
-        ]
-        LOG.info("Copying plaintext legal code")
-        LOG.debug(f"{hostname}:{output_dir}")
-        for text in plaintext_files:
-            if text.startswith("by"):
-                context = "licenses"
-            else:
-                context = "publicdomain"
-            name = text[:-4]
-            relative_name = os.path.join(
-                context,
-                *name.split("_"),
-                "legalcode.txt",
-            )
-            dest_file = os.path.join(output_dir, relative_name)
-            os.makedirs(os.path.dirname(dest_file), exist_ok=True)
-            copyfile(os.path.join(plaintext_dir, text), dest_file)
-            LOG.debug(f"    {relative_name}")
-
     def distill_dev_index(self):
         if not self.options["run"]["distill_dev_index"]:
             return
@@ -424,10 +403,11 @@ class Command(BaseCommand):
             else:
                 LOG.info(
                     f"Distilling {group} deed/legal code HTML and legal code"
-                    " Markdown/RDF/XML"
+                    " Markdown/plain text/RDF/XML"
                 )
             legal_code_arguments = []
             markdown_arguments = []
+            plaintext_arguments = []
             deed_arguments = []
             rdf_arguments = []
             for legal_code in legal_codes[group]:
@@ -440,6 +420,7 @@ class Command(BaseCommand):
                     )
                 )
                 markdown_arguments.append((output_dir, legal_code))
+                plaintext_arguments.append((output_dir, legal_code))
             for tool in tools:
                 for language_code in settings.LANGUAGES_MOSTLY_TRANSLATED:
                     deed_arguments.append(
@@ -477,6 +458,14 @@ class Command(BaseCommand):
                 ):
                     self.pool.starmap(
                         save_legal_code_markdown, markdown_arguments
+                    )
+                if not (
+                    options["filter_apache_redirects"]
+                    or options["filter_license_html"]
+                    or options["filter_license_markdown"]
+                ):
+                    self.pool.starmap(
+                        save_legal_code_plaintext, plaintext_arguments
                     )
             if (
                 not options["filter_apache_redirects"]
@@ -639,7 +628,6 @@ class Command(BaseCommand):
             "copy_static_cc_legal_tools_files": False,
             "copy_static_rdf_files": False,
             "distill_and_symlink_rdf_meta": False,
-            "copy_legal_code_plaintext": False,
             "distill_dev_index": False,
             "pool_distill_lists": False,
             "pool_distill_legal_tools": False,
@@ -682,7 +670,6 @@ class Command(BaseCommand):
         self.config_dir = os.path.abspath(
             os.path.join(self.output_dir, "..", "config")
         )
-        self.legacy_dir = os.path.abspath(settings.LEGACY_DIR)
         git_dir = os.path.abspath(settings.DATA_REPOSITORY_DIR)
         if not self.output_dir.startswith(git_dir):
             raise CommandError(
@@ -700,7 +687,6 @@ class Command(BaseCommand):
         self.copy_static_cc_legal_tools_files()
         self.copy_static_rdf_files()
         self.distill_and_symlink_rdf_meta()
-        self.copy_legal_code_plaintext()
         self.distill_dev_index()
         with Pool() as self.pool:
             self.pool_distill_lists()

--- a/legal_tools/management/commands/publish.py
+++ b/legal_tools/management/commands/publish.py
@@ -43,6 +43,7 @@ LOG_LEVELS = {
 # CNAME
 # https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site
 DOCS_IGNORE = [".nojekyll", "CNAME"]
+FILTER_LICENSE_VERSION_CHOICES = (1.0, 2.0, 2.1, 2.5, 3.0, 4.0)
 
 
 def wrap_relative_symlink(output_dir, relpath, symlink):
@@ -167,7 +168,7 @@ class Command(BaseCommand):
             "--filter-license-html",
             action="store",
             type=float,
-            choices=[1.0, 2.0, 2.1, 2.5, 3.0, 4.0],
+            choices=FILTER_LICENSE_VERSION_CHOICES,
             help="Only distill HTML files for specified license version",
             dest="filter_license_html",
         )
@@ -176,7 +177,7 @@ class Command(BaseCommand):
             "--filter-license-markdown",
             action="store",
             type=float,
-            choices=[1.0, 2.0, 2.1, 2.5, 3.0, 4.0],
+            choices=FILTER_LICENSE_VERSION_CHOICES,
             help="Only distill Markdown files for specified license version",
             dest="filter_license_markdown",
         )

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -1,5 +1,6 @@
 # Standard library
 import re
+import textwrap
 from html import escape
 
 # Third-party
@@ -22,6 +23,7 @@ BLOCK_TAGS = {
     "section",
     "ul",
 }
+MARKDOWN_LINE_LENGTH = 80
 
 
 def legal_code_html_to_markdown(html):
@@ -45,7 +47,7 @@ def _render_block(node):
     if _is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
-        return _clean_inline(str(node))
+        return _wrap_markdown_text(_clean_inline(str(node)))
     if not isinstance(node, Tag):
         return ""
 
@@ -59,12 +61,12 @@ def _render_block(node):
             return f"{'#' * level} {content}"
         return ""
     if tag_name == "p":
-        return _render_inline_children(node)
+        return _wrap_markdown_text(_render_inline_children(node))
     if tag_name == "ol" or tag_name == "ul":
         return _render_list(node)
     if _has_direct_block_child(node):
         return _render_block_children(node)
-    return _render_inline_children(node)
+    return _wrap_markdown_text(_render_inline_children(node))
 
 
 def _render_block_children(node):
@@ -84,7 +86,9 @@ def _render_list(list_tag):
         content = _render_html_list_item(list_item)
         if not content:
             lines.append("<li></li>")
-        elif "\n" in content:
+        elif "\n" in content or len(f"<li>{content}</li>") > (
+            MARKDOWN_LINE_LENGTH
+        ):
             lines.append("<li>")
             lines.extend(content.splitlines())
             lines.append("</li>")
@@ -123,7 +127,7 @@ def _render_html_list_item(list_item):
         content = _render_html_inline_nodes(inline_nodes)
         inline_nodes.clear()
         if content:
-            chunks.append(content)
+            chunks.append(_wrap_html_text(content))
 
     for child in list_item.children:
         if _is_ignorable(child):
@@ -148,7 +152,7 @@ def _render_html_block(node):
     if _is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
-        return escape(_clean_inline(str(node)), quote=False)
+        return _wrap_html_text(escape(_clean_inline(str(node)), quote=False))
     if not isinstance(node, Tag):
         return ""
 
@@ -167,14 +171,15 @@ def _render_html_block(node):
             if (rendered := _render_html_block(child).strip())
         )
     else:
-        content = _render_html_inline_children(node)
+        content = _wrap_html_text(_render_html_inline_children(node))
     return _wrap_html_tag(tag_name, content)
 
 
 def _wrap_html_tag(tag_name, content):
-    if "\n" in content:
+    tag_content = f"<{tag_name}>{content}</{tag_name}>"
+    if "\n" in content or len(tag_content) > MARKDOWN_LINE_LENGTH:
         return f"<{tag_name}>\n{content}\n</{tag_name}>"
-    return f"<{tag_name}>{content}</{tag_name}>"
+    return tag_content
 
 
 def _render_html_inline_nodes(nodes):
@@ -257,6 +262,23 @@ def _render_inline(node):
 def _render_inline_children(node):
     return _clean_inline(
         "".join(_render_inline(child) for child in node.children)
+    )
+
+
+def _wrap_markdown_text(value):
+    return _wrap_text(value)
+
+
+def _wrap_html_text(value):
+    return _wrap_text(value)
+
+
+def _wrap_text(value):
+    return textwrap.fill(
+        value,
+        width=MARKDOWN_LINE_LENGTH,
+        break_long_words=False,
+        break_on_hyphens=False,
     )
 
 

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -1,5 +1,6 @@
 # Standard library
 import re
+from html import escape
 
 # Third-party
 from bs4 import BeautifulSoup, NavigableString, Tag
@@ -27,9 +28,9 @@ def legal_code_html_to_markdown(html):
     """
     Convert rendered legalcode body HTML to Markdown.
 
-    The converter is intentionally small and legalcode-focused. It preserves
-    browser-rendered ordered-list markers such as a/A/i as explicit text
-    because Markdown ordered lists only standardize decimal markers.
+    The converter is intentionally small and legalcode-focused. It emits lists
+    as raw HTML blocks so CommonMark preserves ordered-list semantics such as
+    alpha and roman markers without us recreating list numbering.
     """
     soup = BeautifulSoup(html, "lxml")
     legal_code_body = soup.find(id="legal-code-body")
@@ -75,51 +76,51 @@ def _render_block_children(node):
     return "\n\n".join(chunks)
 
 
-def _render_list(list_tag, indent=0, force_separate_items=False):
-    lines = []
-    start = _get_start(list_tag)
-    list_items = _direct_children(list_tag, "li")
-    separate_items = (
-        force_separate_items or _uses_explicit_ordered_markers(list_tag)
-    )
-    for offset, list_item in enumerate(list_items):
-        number = start + offset
-        marker = _get_list_marker(list_tag, number)
-        content = _render_list_item(list_item).strip()
-        prefix = _get_indent(indent)
+def _render_list(list_tag):
+    tag_name = list_tag.name.lower()
+    attrs = _render_list_attrs(list_tag)
+    lines = [f"<{tag_name}{attrs}>"]
+    for list_item in _direct_children(list_tag, "li"):
+        content = _render_html_list_item(list_item)
         if not content:
-            lines.append(f"{prefix}{marker}")
+            lines.append("<li></li>")
+        elif "\n" in content:
+            lines.append("<li>")
+            lines.extend(content.splitlines())
+            lines.append("</li>")
         else:
-            content_lines = content.splitlines()
-            lines.append(f"{prefix}{marker} {content_lines[0].strip()}")
-            continuation_prefix = _get_indent(indent + 4)
-            for line in content_lines[1:]:
-                if line.strip():
-                    lines.append(f"{continuation_prefix}{line}")
-                else:
-                    lines.append("")
-
-        if separate_items and offset < len(list_items) - 1:
-            lines.append("")
+            lines.append(f"<li>{content}</li>")
+    lines.append(f"</{tag_name}>")
     return "\n".join(lines)
 
 
-def _get_indent(indent):
-    if not indent:
+def _render_list_attrs(list_tag):
+    allowed_attrs = {
+        "ol": ("type", "start", "reversed"),
+        "ul": ("type",),
+    }
+    attrs = []
+    for attr in allowed_attrs[list_tag.name.lower()]:
+        if attr not in list_tag.attrs:
+            continue
+        value = list_tag.get(attr)
+        if attr == "reversed":
+            attrs.append(attr)
+        else:
+            attrs.append(f'{attr}="{escape(str(value), quote=True)}"')
+    if not attrs:
         return ""
-    return "&nbsp;" * indent
+    return f" {' '.join(attrs)}"
 
 
-def _render_list_item(list_item):
+def _render_html_list_item(list_item):
     chunks = []
     inline_nodes = []
 
     def flush_inline_nodes():
         if not inline_nodes:
             return
-        content = _clean_inline(
-            "".join(_render_inline(n) for n in inline_nodes)
-        )
+        content = _render_html_inline_nodes(inline_nodes)
         inline_nodes.clear()
         if content:
             chunks.append(content)
@@ -129,20 +130,94 @@ def _render_list_item(list_item):
             continue
         if isinstance(child, Tag) and child.name.lower() in {"ol", "ul"}:
             flush_inline_nodes()
-            rendered = _render_list(
-                child, force_separate_items=True
-            ).strip()
+            rendered = _render_list(child).strip()
             if rendered:
                 chunks.append(rendered)
         elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
             flush_inline_nodes()
-            rendered = _render_block(child).strip()
+            rendered = _render_html_block(child).strip()
             if rendered:
                 chunks.append(rendered)
         else:
             inline_nodes.append(child)
     flush_inline_nodes()
-    return "\n\n".join(chunks)
+    return "\n".join(chunks)
+
+
+def _render_html_block(node):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return escape(_clean_inline(str(node)), quote=False)
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name in {"script", "style"}:
+        return ""
+    if tag_name in {"ol", "ul"}:
+        return _render_list(node)
+    if tag_name == "li":
+        return _render_html_list_item(node)
+
+    if _has_direct_block_child(node):
+        content = "\n".join(
+            rendered
+            for child in node.children
+            if (rendered := _render_html_block(child).strip())
+        )
+    else:
+        content = _render_html_inline_children(node)
+    return _wrap_html_tag(tag_name, content)
+
+
+def _wrap_html_tag(tag_name, content):
+    if "\n" in content:
+        return f"<{tag_name}>\n{content}\n</{tag_name}>"
+    return f"<{tag_name}>{content}</{tag_name}>"
+
+
+def _render_html_inline_nodes(nodes):
+    return _clean_inline("".join(_render_html_inline(node) for node in nodes))
+
+
+def _render_html_inline(node):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return escape(str(node), quote=False)
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name == "br":
+        return "<br>"
+
+    content = _render_html_inline_children(node)
+    if not content:
+        return ""
+
+    if tag_name in {"b", "strong"}:
+        return f"<strong>{content}</strong>"
+    if tag_name in {"em", "i"}:
+        return f"<em>{content}</em>"
+    if tag_name == "code":
+        return f"<code>{content}</code>"
+    if tag_name == "a":
+        href = node.get("href")
+        if href:
+            href = escape(href, quote=True)
+            return f'<a href="{href}">{content}</a>'
+        return content
+    if tag_name == "u" or _is_underline_span(node):
+        return f"<u>{content}</u>"
+    if tag_name in {"sub", "sup"}:
+        return f"<{tag_name}>{content}</{tag_name}>"
+    return content
+
+
+def _render_html_inline_children(node):
+    return _render_html_inline_nodes(node.children)
 
 
 def _render_inline(node):
@@ -205,70 +280,6 @@ def _direct_children(node, tag_name):
         for child in node.children
         if isinstance(child, Tag) and child.name.lower() == tag_name
     ]
-
-
-def _get_start(list_tag):
-    try:
-        return int(list_tag.get("start", 1))
-    except ValueError:
-        return 1
-
-
-def _uses_explicit_ordered_markers(list_tag):
-    if list_tag.name.lower() != "ol":
-        return False
-    return list_tag.get("type") in {"a", "A", "i", "I"}
-
-
-def _get_list_marker(list_tag, number):
-    if list_tag.name.lower() == "ul":
-        return "-"
-
-    list_type = list_tag.get("type", "1")
-    if list_type in {"1", ""}:
-        return f"{number}."
-    if list_type == "a":
-        return f"({_alpha(number).lower()})"
-    if list_type == "A":
-        return f"({_alpha(number).upper()})"
-    if list_type == "i":
-        return f"({_roman(number).lower()})"
-    if list_type == "I":
-        return f"({_roman(number).upper()})"
-    return f"{number}."
-
-
-def _alpha(number):
-    chars = []
-    while number > 0:
-        number -= 1
-        number, remainder = divmod(number, 26)
-        chars.append(chr(ord("a") + remainder))
-    return "".join(reversed(chars))
-
-
-def _roman(number):
-    numerals = [
-        (1000, "M"),
-        (900, "CM"),
-        (500, "D"),
-        (400, "CD"),
-        (100, "C"),
-        (90, "XC"),
-        (50, "L"),
-        (40, "XL"),
-        (10, "X"),
-        (9, "IX"),
-        (5, "V"),
-        (4, "IV"),
-        (1, "I"),
-    ]
-    result = []
-    for value, symbol in numerals:
-        while number >= value:
-            result.append(symbol)
-            number -= value
-    return "".join(result)
 
 
 def _is_underline_span(node):

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -7,6 +7,9 @@ from html import escape
 from bs4 import BeautifulSoup, NavigableString, Tag
 from bs4.element import Comment
 
+# First-party/Local
+from legal_tools.link_utils import absolute_link_url
+
 BLOCK_TAGS = {
     "article",
     "blockquote",
@@ -370,7 +373,7 @@ def _render_html_inline(node):
     if tag_name == "a":
         href = node.get("href")
         if href:
-            href = escape(href, quote=True)
+            href = escape(absolute_link_url(href), quote=True)
             return f'<a href="{href}">{content}</a>'
         return content
     if tag_name == "u" or _is_underline_span(node):
@@ -409,7 +412,7 @@ def _render_inline(node):
     if tag_name == "a":
         href = node.get("href")
         if href:
-            return f"[{content}]({href})"
+            return f"[{content}]({absolute_link_url(href)})"
         return content
     if tag_name == "u" or _is_underline_span(node):
         return f"<u>{content}</u>"

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -24,6 +24,9 @@ BLOCK_TAGS = {
     "ul",
 }
 MARKDOWN_LINE_LENGTH = 71
+HTML_LIST_INDENT = 2
+LIST_TAGS = {"ol", "ul"}
+IGNORED_TAGS = {"script", "style"}
 
 
 def legal_code_html_to_markdown(html):
@@ -31,8 +34,8 @@ def legal_code_html_to_markdown(html):
     Convert rendered legalcode document/body HTML to Markdown.
 
     The converter is intentionally small and legalcode-focused. It emits lists
-    as raw HTML blocks so CommonMark preserves ordered-list semantics such as
-    alpha and roman markers without us recreating list numbering.
+    as native Markdown when Markdown can preserve the list semantics, and as
+    raw HTML when attributes such as alpha or roman markers require it.
     """
     soup = BeautifulSoup(html, "lxml")
     legal_code_document = soup.find(id="legal-code-document")
@@ -44,59 +47,179 @@ def legal_code_html_to_markdown(html):
     return f"{markdown}\n"
 
 
-def _render_block(node):
+def _render_block(node, indent=0):
     if _is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
-        return _wrap_markdown_text(_clean_inline(str(node)))
+        return _wrap_markdown_text(_clean_inline(str(node)), indent=indent)
     if not isinstance(node, Tag):
         return ""
 
     tag_name = node.name.lower()
-    if tag_name in {"script", "style"}:
+    if tag_name in IGNORED_TAGS:
         return ""
     if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
         level = int(tag_name[1])
         content = _render_inline_children(node)
         if content:
-            return f"{'#' * level} {content}"
+            return f"{' ' * indent}{'#' * level} {content}"
         return ""
     if tag_name == "p":
-        return _wrap_markdown_text(_render_inline_children(node))
-    if tag_name == "ol" or tag_name == "ul":
-        return _render_list(node)
+        return _wrap_markdown_text(_render_inline_children(node), indent=indent)
+    if tag_name in LIST_TAGS:
+        return _render_list(node, indent=indent)
     if _has_direct_block_child(node):
-        return _render_block_children(node)
-    return _wrap_markdown_text(_render_inline_children(node))
+        return _render_block_children(node, indent=indent)
+    return _wrap_markdown_text(_render_inline_children(node), indent=indent)
 
 
-def _render_block_children(node):
+def _render_block_children(node, indent=0):
     chunks = []
     for child in node.children:
-        rendered = _render_block(child).strip()
+        rendered = _strip_rendered(_render_block(child, indent=indent))
         if rendered:
             chunks.append(rendered)
     return "\n\n".join(chunks)
 
 
-def _render_list(list_tag):
+def _render_list(list_tag, indent=0, html_context=False):
+    if html_context or _requires_html_list(list_tag):
+        return _render_html_list(list_tag, indent=indent)
+    return _render_markdown_list(list_tag, indent=indent)
+
+
+def _render_markdown_list(list_tag, indent=0):
+    lines = []
+    is_ordered = list_tag.name.lower() == "ol"
+    start = _get_ordered_list_start(list_tag) if is_ordered else None
+    for offset, list_item in enumerate(_direct_children(list_tag, "li")):
+        marker = f"{start + offset}." if is_ordered else "-"
+        prefix = f"{' ' * indent}{marker} "
+        content_indent = indent + len(marker) + 1
+        chunks = _render_markdown_list_item_chunks(
+            list_item, indent=content_indent
+        )
+        if not chunks:
+            lines.append(prefix.rstrip())
+        else:
+            lines.extend(
+                _render_markdown_list_item(prefix, content_indent, chunks)
+            )
+    return "\n".join(lines)
+
+
+def _render_markdown_list_item(prefix, content_indent, chunks):
+    lines = []
+    for index, (kind, content) in enumerate(chunks):
+        if kind == "text":
+            if index == 0:
+                rendered = _wrap_markdown_text(
+                    content,
+                    initial_indent=prefix,
+                    subsequent_indent=" " * content_indent,
+                )
+            else:
+                rendered = _wrap_markdown_text(
+                    content, indent=content_indent
+                )
+            lines.extend(rendered.splitlines())
+        elif kind == "rendered":
+            if index == 0:
+                lines.append(prefix.rstrip())
+            lines.extend(content.splitlines())
+        else:
+            raise ValueError(f"Unknown Markdown list item chunk kind: {kind}")
+    return lines
+
+
+def _render_markdown_list_item_chunks(list_item, indent=0):
+    chunks = []
+    inline_nodes = []
+
+    def flush_inline_nodes():
+        if not inline_nodes:
+            return
+        content = _render_inline_nodes(inline_nodes)
+        inline_nodes.clear()
+        if content:
+            chunks.append(("text", content))
+
+    for child in list_item.children:
+        if _is_ignorable(child):
+            continue
+        if isinstance(child, Tag) and child.name.lower() == "div":
+            flush_inline_nodes()
+            chunks.extend(
+                _render_markdown_list_item_chunks(child, indent=indent)
+            )
+        elif isinstance(child, Tag) and child.name.lower() in LIST_TAGS:
+            flush_inline_nodes()
+            rendered = _strip_rendered(_render_list(child, indent=indent))
+            if rendered:
+                chunks.append(("rendered", rendered))
+        elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
+            flush_inline_nodes()
+            if child.name.lower() == "p" and not _has_direct_block_child(
+                child
+            ):
+                rendered = _render_inline_children(child)
+                if rendered:
+                    chunks.append(("text", rendered))
+            else:
+                rendered = _strip_rendered(_render_block(child, indent=indent))
+                if rendered:
+                    chunks.append(("rendered", rendered))
+        else:
+            inline_nodes.append(child)
+    flush_inline_nodes()
+    return chunks
+
+
+def _render_html_list(list_tag, indent=0):
     tag_name = list_tag.name.lower()
     attrs = _render_list_attrs(list_tag)
-    lines = [f"<{tag_name}{attrs}>"]
+    list_indent = " " * indent
+    list_item_indent = " " * (indent + HTML_LIST_INDENT)
+    content_indent = indent + (2 * HTML_LIST_INDENT)
+    lines = [f"{list_indent}<{tag_name}{attrs}>"]
     for list_item in _direct_children(list_tag, "li"):
         content = _render_html_list_item(list_item)
         if not content:
-            lines.append("<li></li>")
-        elif "\n" in content or len(f"<li>{content}</li>") > (
-            MARKDOWN_LINE_LENGTH
+            lines.append(f"{list_item_indent}<li></li>")
+        elif (
+            "\n" in content
+            or len(f"{list_item_indent}<li>{content}</li>")
+            > MARKDOWN_LINE_LENGTH
         ):
-            lines.append("<li>")
+            content = _render_html_list_item(list_item, indent=content_indent)
+            lines.append(f"{list_item_indent}<li>")
             lines.extend(content.splitlines())
-            lines.append("</li>")
+            lines.append(f"{list_item_indent}</li>")
         else:
-            lines.append(f"<li>{content}</li>")
-    lines.append(f"</{tag_name}>")
+            lines.append(f"{list_item_indent}<li>{content}</li>")
+    lines.append(f"{list_indent}</{tag_name}>")
     return "\n".join(lines)
+
+
+def _requires_html_list(list_tag):
+    tag_name = list_tag.name.lower()
+    if tag_name == "ul":
+        return list_tag.has_attr("type")
+    if tag_name != "ol":
+        return True
+    if list_tag.has_attr("reversed"):
+        return True
+    list_type = list_tag.get("type", "1")
+    if list_type not in {"", "1"}:
+        return True
+    return _get_ordered_list_start(list_tag) is None
+
+
+def _get_ordered_list_start(list_tag):
+    try:
+        return int(list_tag.get("start", 1))
+    except ValueError:
+        return None
 
 
 def _render_list_attrs(list_tag):
@@ -118,7 +241,7 @@ def _render_list_attrs(list_tag):
     return f" {' '.join(attrs)}"
 
 
-def _render_html_list_item(list_item):
+def _render_html_list_item(list_item, indent=0):
     chunks = []
     inline_nodes = []
 
@@ -128,19 +251,28 @@ def _render_html_list_item(list_item):
         content = _render_html_inline_nodes(inline_nodes)
         inline_nodes.clear()
         if content:
-            chunks.append(_wrap_html_text(content))
+            chunks.append(_wrap_html_text(content, indent=indent))
 
     for child in list_item.children:
         if _is_ignorable(child):
             continue
-        if isinstance(child, Tag) and child.name.lower() in {"ol", "ul"}:
+        if isinstance(child, Tag) and child.name.lower() == "div":
             flush_inline_nodes()
-            rendered = _render_list(child).strip()
+            rendered = _strip_rendered(
+                _render_html_container_children(child, indent=indent)
+            )
             if rendered:
                 chunks.append(rendered)
+        elif isinstance(child, Tag) and child.name.lower() in LIST_TAGS:
+            flush_inline_nodes()
+            rendered = _strip_rendered(_render_list(child, html_context=True))
+            if rendered:
+                chunks.append(_indent_lines(rendered, indent))
         elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
             flush_inline_nodes()
-            rendered = _render_html_block(child).strip()
+            rendered = _strip_rendered(
+                _render_html_block(child, indent=indent)
+            )
             if rendered:
                 chunks.append(rendered)
         else:
@@ -149,42 +281,68 @@ def _render_html_list_item(list_item):
     return "\n".join(chunks)
 
 
-def _render_html_block(node):
+def _render_html_block(node, indent=0):
     if _is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
-        return _wrap_html_text(escape(_clean_inline(str(node)), quote=False))
+        return _wrap_html_text(
+            escape(_clean_inline(str(node)), quote=False), indent=indent
+        )
     if not isinstance(node, Tag):
         return ""
 
     tag_name = node.name.lower()
-    if tag_name in {"script", "style"}:
+    if tag_name in IGNORED_TAGS:
         return ""
-    if tag_name in {"ol", "ul"}:
-        return _render_list(node)
+    if tag_name in LIST_TAGS:
+        return _render_list(node, indent=indent, html_context=True)
     if tag_name == "li":
-        return _render_html_list_item(node)
+        return _render_html_list_item(node, indent=indent)
+    if tag_name == "div":
+        return _render_html_container_children(node, indent=indent)
 
     if _has_direct_block_child(node):
         content = "\n".join(
             rendered
             for child in node.children
-            if (rendered := _render_html_block(child).strip())
+            if (
+                rendered := _strip_rendered(
+                    _render_html_block(
+                        child, indent=indent + HTML_LIST_INDENT
+                    )
+                )
+            )
+        )
+        return _wrap_html_tag(
+            tag_name, content, indent=indent, content_indented=True
         )
     else:
-        content = _wrap_html_text(_render_html_inline_children(node))
-    return _wrap_html_tag(tag_name, content)
+        content = _render_html_inline_children(node)
+    return _wrap_html_tag(tag_name, content, indent=indent)
 
 
-def _wrap_html_tag(tag_name, content):
-    tag_content = f"<{tag_name}>{content}</{tag_name}>"
+def _render_html_container_children(node, indent=0):
+    return _render_html_list_item(node, indent=indent)
+
+
+def _wrap_html_tag(tag_name, content, indent=0, content_indented=False):
+    line_indent = " " * indent
+    tag_content = f"{line_indent}<{tag_name}>{content}</{tag_name}>"
     if "\n" in content or len(tag_content) > MARKDOWN_LINE_LENGTH:
-        return f"<{tag_name}>\n{content}\n</{tag_name}>"
+        if not content_indented:
+            content = _wrap_html_text(
+                content, indent=indent + HTML_LIST_INDENT
+            )
+        return f"{line_indent}<{tag_name}>\n{content}\n{line_indent}</{tag_name}>"
     return tag_content
 
 
 def _render_html_inline_nodes(nodes):
     return _clean_inline("".join(_render_html_inline(node) for node in nodes))
+
+
+def _render_inline_nodes(nodes):
+    return _clean_inline("".join(_render_inline(node) for node in nodes))
 
 
 def _render_html_inline(node):
@@ -266,21 +424,46 @@ def _render_inline_children(node):
     )
 
 
-def _wrap_markdown_text(value):
-    return _wrap_text(value)
+def _wrap_markdown_text(
+    value, indent=0, initial_indent=None, subsequent_indent=None
+):
+    return _wrap_text(
+        value,
+        indent=indent,
+        initial_indent=initial_indent,
+        subsequent_indent=subsequent_indent,
+    )
 
 
-def _wrap_html_text(value):
-    return _wrap_text(value)
+def _wrap_html_text(value, indent=0):
+    return _wrap_text(value, indent=indent)
 
 
-def _wrap_text(value):
+def _wrap_text(value, indent=0, initial_indent=None, subsequent_indent=None):
+    if initial_indent is None:
+        initial_indent = " " * indent
+    if subsequent_indent is None:
+        subsequent_indent = " " * indent
     return textwrap.fill(
         value,
         width=MARKDOWN_LINE_LENGTH,
+        initial_indent=initial_indent,
+        subsequent_indent=subsequent_indent,
         break_long_words=False,
         break_on_hyphens=False,
     )
+
+
+def _indent_lines(value, indent):
+    line_indent = " " * indent
+    return "\n".join(f"{line_indent}{line}" for line in value.splitlines())
+
+
+def _strip_rendered(value):
+    value = value.strip("\n")
+    if not value.strip():
+        return ""
+    return value
 
 
 def _clean_inline(value):

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -23,20 +23,21 @@ BLOCK_TAGS = {
     "section",
     "ul",
 }
-MARKDOWN_LINE_LENGTH = 80
+MARKDOWN_LINE_LENGTH = 70
 
 
 def legal_code_html_to_markdown(html):
     """
-    Convert rendered legalcode body HTML to Markdown.
+    Convert rendered legalcode document/body HTML to Markdown.
 
     The converter is intentionally small and legalcode-focused. It emits lists
     as raw HTML blocks so CommonMark preserves ordered-list semantics such as
     alpha and roman markers without us recreating list numbering.
     """
     soup = BeautifulSoup(html, "lxml")
+    legal_code_document = soup.find(id="legal-code-document")
     legal_code_body = soup.find(id="legal-code-body")
-    root = legal_code_body or soup.body or soup
+    root = legal_code_document or legal_code_body or soup.body or soup
     markdown = _render_block(root).strip()
     if not markdown:
         return ""
@@ -55,7 +56,7 @@ def _render_block(node):
     if tag_name in {"script", "style"}:
         return ""
     if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
-        level = max(int(tag_name[1]) - 1, 1)
+        level = int(tag_name[1])
         content = _render_inline_children(node)
         if content:
             return f"{'#' * level} {content}"

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -1,35 +1,27 @@
 # Standard library
-import re
 import textwrap
 from html import escape
 
 # Third-party
-from bs4 import BeautifulSoup, NavigableString, Tag
-from bs4.element import Comment
+from bs4 import NavigableString, Tag
 
 # First-party/Local
-from legal_tools.link_utils import absolute_link_url
+from legal_tools.link_utils import absolute_link_url, markdown_link
+from legal_tools.render_utils import (
+    BLOCK_TAGS,
+    HEADING_TAGS,
+    IGNORED_TAGS,
+    LIST_TAGS,
+    TEXT_LINE_LENGTH,
+    clean_inline_spacing,
+    direct_children,
+    has_direct_block_child,
+    is_ignorable,
+    legal_code_root,
+)
 
-BLOCK_TAGS = {
-    "article",
-    "blockquote",
-    "div",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "li",
-    "ol",
-    "p",
-    "section",
-    "ul",
-}
-MARKDOWN_LINE_LENGTH = 71
+MARKDOWN_LINE_LENGTH = TEXT_LINE_LENGTH
 HTML_LIST_INDENT = 2
-LIST_TAGS = {"ol", "ul"}
-IGNORED_TAGS = {"script", "style"}
 
 
 def legal_code_html_to_markdown(html):
@@ -40,10 +32,7 @@ def legal_code_html_to_markdown(html):
     as native Markdown when Markdown can preserve the list semantics, and as
     raw HTML when attributes such as alpha or roman markers require it.
     """
-    soup = BeautifulSoup(html, "lxml")
-    legal_code_document = soup.find(id="legal-code-document")
-    legal_code_body = soup.find(id="legal-code-body")
-    root = legal_code_document or legal_code_body or soup.body or soup
+    root = legal_code_root(html)
     markdown = _render_block(root).strip()
     if not markdown:
         return ""
@@ -51,17 +40,19 @@ def legal_code_html_to_markdown(html):
 
 
 def _render_block(node, indent=0):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
-        return _wrap_markdown_text(_clean_inline(str(node)), indent=indent)
+        return _wrap_markdown_text(
+            clean_inline_spacing(str(node)), indent=indent
+        )
     if not isinstance(node, Tag):
         return ""
 
     tag_name = node.name.lower()
     if tag_name in IGNORED_TAGS:
         return ""
-    if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+    if tag_name in HEADING_TAGS:
         level = int(tag_name[1])
         content = _render_inline_children(node)
         if content:
@@ -71,7 +62,7 @@ def _render_block(node, indent=0):
         return _wrap_markdown_text(_render_inline_children(node), indent=indent)
     if tag_name in LIST_TAGS:
         return _render_list(node, indent=indent)
-    if _has_direct_block_child(node):
+    if has_direct_block_child(node):
         return _render_block_children(node, indent=indent)
     return _wrap_markdown_text(_render_inline_children(node), indent=indent)
 
@@ -95,7 +86,7 @@ def _render_markdown_list(list_tag, indent=0):
     lines = []
     is_ordered = list_tag.name.lower() == "ol"
     start = _get_ordered_list_start(list_tag) if is_ordered else None
-    for offset, list_item in enumerate(_direct_children(list_tag, "li")):
+    for offset, list_item in enumerate(direct_children(list_tag, "li")):
         marker = f"{start + offset}." if is_ordered else "-"
         prefix = f"{' ' * indent}{marker} "
         content_indent = indent + len(marker) + 1
@@ -148,7 +139,7 @@ def _render_markdown_list_item_chunks(list_item, indent=0):
             chunks.append(("text", content))
 
     for child in list_item.children:
-        if _is_ignorable(child):
+        if is_ignorable(child):
             continue
         if isinstance(child, Tag) and child.name.lower() == "div":
             flush_inline_nodes()
@@ -162,7 +153,7 @@ def _render_markdown_list_item_chunks(list_item, indent=0):
                 chunks.append(("rendered", rendered))
         elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
             flush_inline_nodes()
-            if child.name.lower() == "p" and not _has_direct_block_child(
+            if child.name.lower() == "p" and not has_direct_block_child(
                 child
             ):
                 rendered = _render_inline_children(child)
@@ -185,7 +176,7 @@ def _render_html_list(list_tag, indent=0):
     list_item_indent = " " * (indent + HTML_LIST_INDENT)
     content_indent = indent + (2 * HTML_LIST_INDENT)
     lines = [f"{list_indent}<{tag_name}{attrs}>"]
-    for list_item in _direct_children(list_tag, "li"):
+    for list_item in direct_children(list_tag, "li"):
         content = _render_html_list_item(list_item)
         if not content:
             lines.append(f"{list_item_indent}<li></li>")
@@ -257,7 +248,7 @@ def _render_html_list_item(list_item, indent=0):
             chunks.append(_wrap_html_text(content, indent=indent))
 
     for child in list_item.children:
-        if _is_ignorable(child):
+        if is_ignorable(child):
             continue
         if isinstance(child, Tag) and child.name.lower() == "div":
             flush_inline_nodes()
@@ -285,11 +276,12 @@ def _render_html_list_item(list_item, indent=0):
 
 
 def _render_html_block(node, indent=0):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
         return _wrap_html_text(
-            escape(_clean_inline(str(node)), quote=False), indent=indent
+            escape(clean_inline_spacing(str(node)), quote=False),
+            indent=indent,
         )
     if not isinstance(node, Tag):
         return ""
@@ -304,7 +296,7 @@ def _render_html_block(node, indent=0):
     if tag_name == "div":
         return _render_html_container_children(node, indent=indent)
 
-    if _has_direct_block_child(node):
+    if has_direct_block_child(node):
         content = "\n".join(
             rendered
             for child in node.children
@@ -341,15 +333,17 @@ def _wrap_html_tag(tag_name, content, indent=0, content_indented=False):
 
 
 def _render_html_inline_nodes(nodes):
-    return _clean_inline("".join(_render_html_inline(node) for node in nodes))
+    return clean_inline_spacing(
+        "".join(_render_html_inline(node) for node in nodes)
+    )
 
 
 def _render_inline_nodes(nodes):
-    return _clean_inline("".join(_render_inline(node) for node in nodes))
+    return clean_inline_spacing("".join(_render_inline(node) for node in nodes))
 
 
 def _render_html_inline(node):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
         return escape(str(node), quote=False)
@@ -388,7 +382,7 @@ def _render_html_inline_children(node):
 
 
 def _render_inline(node):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
         return str(node)
@@ -412,7 +406,7 @@ def _render_inline(node):
     if tag_name == "a":
         href = node.get("href")
         if href:
-            return f"[{content}]({absolute_link_url(href)})"
+            return markdown_link(content, href)
         return content
     if tag_name == "u" or _is_underline_span(node):
         return f"<u>{content}</u>"
@@ -422,7 +416,7 @@ def _render_inline(node):
 
 
 def _render_inline_children(node):
-    return _clean_inline(
+    return clean_inline_spacing(
         "".join(_render_inline(child) for child in node.children)
     )
 
@@ -469,38 +463,8 @@ def _strip_rendered(value):
     return value
 
 
-def _clean_inline(value):
-    value = re.sub(r"\s+", " ", value)
-    value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
-    value = re.sub(r"([(\[])\s+", r"\1", value)
-    return value.strip()
-
-
-def _has_direct_block_child(node):
-    return any(
-        isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS
-        for child in node.children
-    )
-
-
-def _direct_children(node, tag_name):
-    return [
-        child
-        for child in node.children
-        if isinstance(child, Tag) and child.name.lower() == tag_name
-    ]
-
-
 def _is_underline_span(node):
     if node.name.lower() != "span":
         return False
     style = node.get("style", "").lower().replace(" ", "")
     return "text-decoration:underline" in style
-
-
-def _is_ignorable(node):
-    if isinstance(node, Comment):
-        return True
-    if isinstance(node, NavigableString):
-        return not str(node).strip()
-    return False

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -52,7 +52,7 @@ def _render_block(node):
     if tag_name in {"script", "style"}:
         return ""
     if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
-        level = int(tag_name[1])
+        level = max(int(tag_name[1]) - 1, 1)
         content = _render_inline_children(node)
         if content:
             return f"{'#' * level} {content}"

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -1,0 +1,286 @@
+# Standard library
+import re
+
+# Third-party
+from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4.element import Comment
+
+BLOCK_TAGS = {
+    "article",
+    "blockquote",
+    "div",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "li",
+    "ol",
+    "p",
+    "section",
+    "ul",
+}
+
+
+def legal_code_html_to_markdown(html):
+    """
+    Convert rendered legalcode body HTML to Markdown.
+
+    The converter is intentionally small and legalcode-focused. It preserves
+    browser-rendered ordered-list markers such as a/A/i as explicit text
+    because Markdown ordered lists only standardize decimal markers.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    legal_code_body = soup.find(id="legal-code-body")
+    root = legal_code_body or soup.body or soup
+    markdown = _render_block(root).strip()
+    if not markdown:
+        return ""
+    return f"{markdown}\n"
+
+
+def _render_block(node):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return _clean_inline(str(node))
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name in {"script", "style"}:
+        return ""
+    if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+        level = int(tag_name[1])
+        content = _render_inline_children(node)
+        if content:
+            return f"{'#' * level} {content}"
+        return ""
+    if tag_name == "p":
+        return _render_inline_children(node)
+    if tag_name == "ol" or tag_name == "ul":
+        return _render_list(node)
+    if _has_direct_block_child(node):
+        return _render_block_children(node)
+    return _render_inline_children(node)
+
+
+def _render_block_children(node):
+    chunks = []
+    for child in node.children:
+        rendered = _render_block(child).strip()
+        if rendered:
+            chunks.append(rendered)
+    return "\n\n".join(chunks)
+
+
+def _render_list(list_tag, indent=0, force_separate_items=False):
+    lines = []
+    start = _get_start(list_tag)
+    list_items = _direct_children(list_tag, "li")
+    separate_items = (
+        force_separate_items or _uses_explicit_ordered_markers(list_tag)
+    )
+    for offset, list_item in enumerate(list_items):
+        number = start + offset
+        marker = _get_list_marker(list_tag, number)
+        content = _render_list_item(list_item).strip()
+        prefix = _get_indent(indent)
+        if not content:
+            lines.append(f"{prefix}{marker}")
+        else:
+            content_lines = content.splitlines()
+            lines.append(f"{prefix}{marker} {content_lines[0].strip()}")
+            continuation_prefix = _get_indent(indent + 4)
+            for line in content_lines[1:]:
+                if line.strip():
+                    lines.append(f"{continuation_prefix}{line}")
+                else:
+                    lines.append("")
+
+        if separate_items and offset < len(list_items) - 1:
+            lines.append("")
+    return "\n".join(lines)
+
+
+def _get_indent(indent):
+    if not indent:
+        return ""
+    return "&nbsp;" * indent
+
+
+def _render_list_item(list_item):
+    chunks = []
+    inline_nodes = []
+
+    def flush_inline_nodes():
+        if not inline_nodes:
+            return
+        content = _clean_inline(
+            "".join(_render_inline(n) for n in inline_nodes)
+        )
+        inline_nodes.clear()
+        if content:
+            chunks.append(content)
+
+    for child in list_item.children:
+        if _is_ignorable(child):
+            continue
+        if isinstance(child, Tag) and child.name.lower() in {"ol", "ul"}:
+            flush_inline_nodes()
+            rendered = _render_list(
+                child, force_separate_items=True
+            ).strip()
+            if rendered:
+                chunks.append(rendered)
+        elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
+            flush_inline_nodes()
+            rendered = _render_block(child).strip()
+            if rendered:
+                chunks.append(rendered)
+        else:
+            inline_nodes.append(child)
+    flush_inline_nodes()
+    return "\n\n".join(chunks)
+
+
+def _render_inline(node):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return str(node)
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name == "br":
+        return "\n"
+
+    content = _render_inline_children(node)
+    if not content:
+        return ""
+
+    if tag_name in {"b", "strong"}:
+        return f"**{content}**"
+    if tag_name in {"em", "i"}:
+        return f"*{content}*"
+    if tag_name == "code":
+        return f"`{content}`"
+    if tag_name == "a":
+        href = node.get("href")
+        if href:
+            return f"[{content}]({href})"
+        return content
+    if tag_name == "u" or _is_underline_span(node):
+        return f"<u>{content}</u>"
+    if tag_name in {"sub", "sup"}:
+        return f"<{tag_name}>{content}</{tag_name}>"
+    return content
+
+
+def _render_inline_children(node):
+    return _clean_inline(
+        "".join(_render_inline(child) for child in node.children)
+    )
+
+
+def _clean_inline(value):
+    value = re.sub(r"\s+", " ", value)
+    value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
+    value = re.sub(r"([(\[])\s+", r"\1", value)
+    return value.strip()
+
+
+def _has_direct_block_child(node):
+    return any(
+        isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS
+        for child in node.children
+    )
+
+
+def _direct_children(node, tag_name):
+    return [
+        child
+        for child in node.children
+        if isinstance(child, Tag) and child.name.lower() == tag_name
+    ]
+
+
+def _get_start(list_tag):
+    try:
+        return int(list_tag.get("start", 1))
+    except ValueError:
+        return 1
+
+
+def _uses_explicit_ordered_markers(list_tag):
+    if list_tag.name.lower() != "ol":
+        return False
+    return list_tag.get("type") in {"a", "A", "i", "I"}
+
+
+def _get_list_marker(list_tag, number):
+    if list_tag.name.lower() == "ul":
+        return "-"
+
+    list_type = list_tag.get("type", "1")
+    if list_type in {"1", ""}:
+        return f"{number}."
+    if list_type == "a":
+        return f"({_alpha(number).lower()})"
+    if list_type == "A":
+        return f"({_alpha(number).upper()})"
+    if list_type == "i":
+        return f"({_roman(number).lower()})"
+    if list_type == "I":
+        return f"({_roman(number).upper()})"
+    return f"{number}."
+
+
+def _alpha(number):
+    chars = []
+    while number > 0:
+        number -= 1
+        number, remainder = divmod(number, 26)
+        chars.append(chr(ord("a") + remainder))
+    return "".join(reversed(chars))
+
+
+def _roman(number):
+    numerals = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+    result = []
+    for value, symbol in numerals:
+        while number >= value:
+            result.append(symbol)
+            number -= value
+    return "".join(result)
+
+
+def _is_underline_span(node):
+    if node.name.lower() != "span":
+        return False
+    style = node.get("style", "").lower().replace(" ", "")
+    return "text-decoration:underline" in style
+
+
+def _is_ignorable(node):
+    if isinstance(node, Comment):
+        return True
+    if isinstance(node, NavigableString):
+        return not str(node).strip()
+    return False

--- a/legal_tools/markdown_utils.py
+++ b/legal_tools/markdown_utils.py
@@ -23,7 +23,7 @@ BLOCK_TAGS = {
     "section",
     "ul",
 }
-MARKDOWN_LINE_LENGTH = 70
+MARKDOWN_LINE_LENGTH = 71
 
 
 def legal_code_html_to_markdown(html):

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -297,6 +297,21 @@ class LegalCode(models.Model):
 
         return [relpath, symlinks, redirects_data]
 
+    def get_markdown_publish_files(self):
+        """
+        Generate relative path for legal code Markdown files.
+        """
+        language_code = self.language_code
+        tool = self.tool
+        filename = f"legalcode.{language_code}.md"
+
+        if tool.deed_only:
+            relpath = None
+        else:
+            relpath = os.path.join(tool._get_save_path(), filename)
+
+        return relpath
+
     def get_redirect_pairs(self):
         language_code = self.language_code
         tool = self.tool

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -228,18 +228,17 @@ class LegalCode(models.Model):
             "legalcode",
             self.language_code,
         )
-        # NOTE: plaintext functionality disabled
-        # unit = self.tool.unit
-        # if (
-        #     (unit in UNITS_LICENSES and float(self.tool.version) > 2.5)
-        #     or unit == "zero"
-        # ) and self.language_code == "en":
-        #     self.plain_text_url = build_path(
-        #         self.tool.base_url,
-        #         "legalcode.txt",
-        #         self.language_code,
-        #     )
         super().save(*args, **kwargs)
+
+    def get_plaintext_publish_file(self):
+        """
+        Generate relative path for generated legal code plain text files.
+        """
+        tool = self.tool
+        if tool.deed_only:
+            return None
+        filename = f"legalcode.{self.language_code}.txt"
+        return os.path.join(tool._get_save_path(), filename)
 
     def get_publish_files(self):
         """
@@ -813,7 +812,7 @@ class TranslationBranch(models.Model):
 
 def build_path(base_url, document, language_code=None):
     path = base_url.replace(settings.CANONICAL_SITE, "")
-    if document == "legalcode.txt" or not language_code:
+    if not language_code:
         path = posixpath.join(path, document)
     else:
         path = posixpath.join(path, f"{document}.{language_code}")

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -1,4 +1,5 @@
 # Standard library
+from dataclasses import dataclass
 import re
 import textwrap
 
@@ -8,8 +9,7 @@ from bs4.element import Comment
 
 PLAIN_TEXT_LINE_LENGTH = 71
 PLAIN_TEXT_SEPARATOR = "=" * PLAIN_TEXT_LINE_LENGTH
-LIST_INDENT = 5
-LIST_MARKER_WIDTH = 3
+LIST_MIN_PREFIX_WIDTH = 5
 NOTICE_ASIDE_INDENT = 5
 EN_DASH_PLACEHOLDER = "\ue000\ue001"
 _SECTION_REFERENCE_RE = re.compile(
@@ -50,6 +50,11 @@ class PlainTextRenderError(ValueError):
     pass
 
 
+@dataclass(frozen=True)
+class _PlainTextRenderContext:
+    list_prefix_width: int
+
+
 class _PlainTextWrapper(textwrap.TextWrapper):
     def _split(self, text):
         chunks = super()._split(text)
@@ -72,17 +77,34 @@ def legal_code_html_to_plain_text(html):
     legal_code_document = soup.find(id="legal-code-document")
     legal_code_body = soup.find(id="legal-code-body")
     root = legal_code_document or legal_code_body or soup.body or soup
+    context = _build_render_context(root)
     if legal_code_document:
-        plain_text = _render_document(root).strip("\n")
+        plain_text = _render_document(root, context).strip("\n")
     else:
-        plain_text = _render_block(root).strip("\n")
+        plain_text = _render_block(root, context).strip("\n")
     if not plain_text:
         return ""
     plain_text = _restore_plain_text_tokens(plain_text)
     return f"{plain_text}\n"
 
 
-def _render_document(document):
+def _build_render_context(root):
+    longest_marker = 0
+    for list_tag in root.find_all("ol"):
+        list_items = _direct_children(list_tag, "li")
+        start = _get_start(list_tag, len(list_items))
+        for offset, _list_item in enumerate(list_items):
+            number = (
+                start - offset if _is_reversed(list_tag) else start + offset
+            )
+            marker = _get_list_marker(list_tag, number)
+            longest_marker = max(longest_marker, len(marker))
+    return _PlainTextRenderContext(
+        list_prefix_width=max(LIST_MIN_PREFIX_WIDTH, longest_marker + 2)
+    )
+
+
+def _render_document(document, context):
     sections = []
     current_region = None
     current_chunks = []
@@ -97,7 +119,7 @@ def _render_document(document):
 
     for child in _non_ignorable_children(document):
         region = _document_region(child)
-        rendered = _render_block(child)
+        rendered = _render_block(child, context)
         if _preserves_trailing_spacing(child):
             rendered = rendered.lstrip("\n")
         else:
@@ -126,7 +148,7 @@ def _document_region(node):
     return "other"
 
 
-def _render_block(node, indent=0):
+def _render_block(node, context, indent=0):
     if _is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
@@ -144,24 +166,24 @@ def _render_block(node, indent=0):
     if tag_name == "p":
         return _wrap_text(_render_inline_children(node), indent=indent)
     if tag_name in _LIST_TAGS:
-        return _render_list(node, indent=indent)
+        return _render_list(node, context, indent=indent)
     if node.get("id") == "legal-code-body":
-        return _render_legal_code_body(node, indent=indent)
+        return _render_legal_code_body(node, context, indent=indent)
     if node.get("id") == "about-cc-and-license":
-        return _render_about_cc_and_license(node, indent=indent)
+        return _render_about_cc_and_license(node, context, indent=indent)
     if _has_direct_block_child(node):
-        return _render_block_children(node, indent=indent)
+        return _render_block_children(node, context, indent=indent)
     return _wrap_text(_render_inline_children(node), indent=indent)
 
 
-def _render_block_children(node, indent=0):
-    return _render_block_nodes(node.children, indent=indent)
+def _render_block_children(node, context, indent=0):
+    return _render_block_nodes(node.children, context, indent=indent)
 
 
-def _render_block_nodes(nodes, indent=0):
+def _render_block_nodes(nodes, context, indent=0):
     chunks = []
     for child in nodes:
-        _append_rendered(chunks, _render_block(child, indent=indent))
+        _append_rendered(chunks, _render_block(child, context, indent=indent))
     return "\n\n".join(chunks)
 
 
@@ -175,10 +197,12 @@ def _strip_rendered(rendered):
     return rendered.strip("\n")
 
 
-def _render_legal_code_body(node, indent=0):
+def _render_legal_code_body(node, context, indent=0):
     chunks = []
     for is_section, group in _legal_code_body_groups(node):
-        rendered = _strip_rendered(_render_block_nodes(group, indent=indent))
+        rendered = _strip_rendered(
+            _render_block_nodes(group, context, indent=indent)
+        )
         if not rendered.strip():
             continue
         if is_section:
@@ -209,7 +233,7 @@ def _legal_code_body_groups(node):
     return groups
 
 
-def _render_about_cc_and_license(node, indent=0):
+def _render_about_cc_and_license(node, context, indent=0):
     chunks = []
     ordinary_nodes = []
     children = _non_ignorable_children(node)
@@ -218,7 +242,9 @@ def _render_about_cc_and_license(node, indent=0):
     def flush_ordinary_nodes():
         if not ordinary_nodes:
             return
-        rendered = _render_block_nodes(ordinary_nodes, indent=indent)
+        rendered = _render_block_nodes(
+            ordinary_nodes, context, indent=indent
+        )
         _append_rendered(chunks, rendered)
         ordinary_nodes.clear()
 
@@ -233,7 +259,9 @@ def _render_about_cc_and_license(node, indent=0):
             ):
                 notice_nodes.append(children[index])
                 index += 1
-            rendered = _render_notice_aside(notice_nodes, indent=indent)
+            rendered = _render_notice_aside(
+                notice_nodes, context, indent=indent
+            )
             _append_rendered(chunks, rendered)
             continue
         if not _is_divider(child):
@@ -262,16 +290,16 @@ def _is_heading_at_or_above(node, level):
     return bool(match and int(match.group(1)) <= level)
 
 
-def _render_notice_aside(nodes, indent=0):
+def _render_notice_aside(nodes, context, indent=0):
     heading = _render_inline_children(nodes[0])
     if not heading:
-        return _render_block_nodes(nodes[1:], indent=indent)
+        return _render_block_nodes(nodes[1:], context, indent=indent)
 
     prefix = heading if heading.endswith(":") else f"{heading}:"
     content = " ".join(
         part
         for part in (
-            _render_notice_aside_text(node) for node in nodes[1:]
+            _render_notice_aside_text(node, context) for node in nodes[1:]
         )
         if part
     )
@@ -285,7 +313,7 @@ def _render_notice_aside(nodes, indent=0):
     )
 
 
-def _render_notice_aside_text(node):
+def _render_notice_aside_text(node, context):
     if _is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
@@ -298,10 +326,10 @@ def _render_notice_aside_text(node):
         return ""
     if not _has_direct_block_child(node):
         return _render_inline_children(node)
-    return _clean_inline(_render_block(node))
+    return _clean_inline(_render_block(node, context))
 
 
-def _render_list(list_tag, indent=0):
+def _render_list(list_tag, context, indent=0):
     rendered_items = []
     is_ordered = list_tag.name.lower() == "ol"
     list_items = _direct_children(list_tag, "li")
@@ -312,11 +340,11 @@ def _render_list(list_tag, indent=0):
                 start - offset if _is_reversed(list_tag) else start + offset
             )
             marker = _get_list_marker(list_tag, number)
-            prefix = f"{' ' * indent}{_format_marker(marker)}"
+            prefix = f"{' ' * indent}{_format_marker(marker, context)}"
         else:
-            prefix = f"{' ' * indent}{_format_unordered_marker()}"
-        content_indent = max(indent + LIST_INDENT, len(prefix))
-        chunks = _render_list_item_chunks(list_item, content_indent)
+            prefix = f"{' ' * indent}{_format_unordered_marker(context)}"
+        content_indent = indent + context.list_prefix_width
+        chunks = _render_list_item_chunks(list_item, context, content_indent)
         if not chunks:
             rendered_items.append(prefix.rstrip())
         else:
@@ -350,7 +378,7 @@ def _render_list_item(prefix, content_indent, chunks):
     return lines
 
 
-def _render_list_item_chunks(list_item, content_indent):
+def _render_list_item_chunks(list_item, context, content_indent):
     chunks = []
     inline_nodes = []
 
@@ -365,11 +393,13 @@ def _render_list_item_chunks(list_item, content_indent):
     for child in _non_ignorable_children(list_item):
         if isinstance(child, Tag) and child.name.lower() == "div":
             flush_inline_nodes()
-            chunks.extend(_render_list_item_chunks(child, content_indent))
+            chunks.extend(
+                _render_list_item_chunks(child, context, content_indent)
+            )
         elif isinstance(child, Tag) and child.name.lower() in _LIST_TAGS:
             flush_inline_nodes()
             rendered = _strip_rendered(
-                _render_list(child, indent=content_indent)
+                _render_list(child, context, indent=content_indent)
             )
             if rendered.strip():
                 chunks.append((_LIST_CHUNK_RENDERED, rendered))
@@ -383,7 +413,7 @@ def _render_list_item_chunks(list_item, content_indent):
                     chunks.append((_LIST_CHUNK_TEXT, rendered))
             else:
                 rendered = _strip_rendered(
-                    _render_block(child, indent=content_indent)
+                    _render_block(child, context, indent=content_indent)
                 )
                 if rendered.strip():
                     chunks.append((_LIST_CHUNK_RENDERED, rendered))
@@ -395,17 +425,13 @@ def _render_list_item_chunks(list_item, content_indent):
     return chunks
 
 
-def _format_marker(marker):
-    if len(marker) > LIST_MARKER_WIDTH:
-        raise PlainTextRenderError(
-            f"List marker exceeds {LIST_MARKER_WIDTH} characters: {marker}"
-        )
-    marker = marker.rjust(LIST_MARKER_WIDTH)
+def _format_marker(marker, context):
+    marker = marker.rjust(context.list_prefix_width - 2)
     return f"{marker}. "
 
 
-def _format_unordered_marker():
-    return f"{'-'.rjust(LIST_INDENT - 1)} "
+def _format_unordered_marker(context):
+    return f"{'-'.rjust(context.list_prefix_width - 1)} "
 
 
 def _get_start(list_tag, list_length):

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -2,16 +2,29 @@
 from dataclasses import dataclass
 import re
 import textwrap
-from urllib.parse import urlsplit
 
 # Third-party
-from bs4 import BeautifulSoup, NavigableString, Tag
-from bs4.element import Comment
+from bs4 import NavigableString, Tag
 
 # First-party/Local
-from legal_tools.link_utils import absolute_link_url
+from legal_tools.link_utils import display_link_label_url, display_link_url
+from legal_tools.render_utils import (
+    BLOCK_TAGS,
+    HEADING_TAGS,
+    IGNORED_TAGS,
+    LIST_TAGS,
+    TEXT_LINE_LENGTH,
+    clean_inline_spacing,
+    direct_children,
+    has_class,
+    has_direct_block_child,
+    is_ignorable,
+    is_tag,
+    legal_code_root,
+    non_ignorable_children,
+)
 
-PLAIN_TEXT_LINE_LENGTH = 71
+PLAIN_TEXT_LINE_LENGTH = TEXT_LINE_LENGTH
 PLAIN_TEXT_SEPARATOR = "=" * PLAIN_TEXT_LINE_LENGTH
 LIST_MIN_PREFIX_WIDTH = 5
 NOTICE_ASIDE_INDENT = 5
@@ -21,38 +34,13 @@ _SECTION_REFERENCE_RE = re.compile(
     r"([.,;:!?]*)$"
 )
 _SECTION_REFERENCE_PART_RE = re.compile(r"\([A-Za-z0-9]+\)")
-_IGNORED_TAGS = {"script", "style", "hr"}
-_HEADING_TAGS = {"h1", "h2", "h3", "h4", "h5", "h6"}
-_LIST_TAGS = {"ol", "ul"}
+_IGNORED_TAGS = IGNORED_TAGS | {"hr"}
 _LIST_CHUNK_TEXT = "text"
 _LIST_CHUNK_RENDERED = "rendered"
 _NOTICE_ASIDE_CLASSES = {"level", "is-vcentered", "b-header"}
-_DOMAIN_LIKE_URL_RE = re.compile(
-    r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?(?=[/?#]|$)"
-)
-_EMAIL_LIKE_URL_RE = re.compile(
-    r"^[^\s@]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
-)
 _SKIPPED_NOTICE_HEADING_PARENT_IDS = {
     "notice-about-licenses-and-cc",
     "notice-about-cc-and-trademark",
-}
-
-BLOCK_TAGS = {
-    "article",
-    "blockquote",
-    "div",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "li",
-    "ol",
-    "p",
-    "section",
-    "ul",
 }
 
 
@@ -83,12 +71,9 @@ def legal_code_html_to_plain_text(html):
     HTML/CSS use for visual separation, and it renders ordered-list markers
     explicitly because plain text has no list semantics.
     """
-    soup = BeautifulSoup(html, "lxml")
-    legal_code_document = soup.find(id="legal-code-document")
-    legal_code_body = soup.find(id="legal-code-body")
-    root = legal_code_document or legal_code_body or soup.body or soup
+    root = legal_code_root(html)
     context = _build_render_context(root)
-    if legal_code_document:
+    if isinstance(root, Tag) and root.get("id") == "legal-code-document":
         plain_text = _render_document(root, context).strip("\n")
     else:
         plain_text = _render_block(root, context).strip("\n")
@@ -101,7 +86,7 @@ def legal_code_html_to_plain_text(html):
 def _build_render_context(root):
     longest_marker = 0
     for list_tag in root.find_all("ol"):
-        list_items = _direct_children(list_tag, "li")
+        list_items = direct_children(list_tag, "li")
         start = _get_start(list_tag, len(list_items))
         for offset, _list_item in enumerate(list_items):
             number = (
@@ -127,7 +112,7 @@ def _render_document(document, context):
         current_region = None
         current_chunks = []
 
-    for child in _non_ignorable_children(document):
+    for child in non_ignorable_children(document):
         region = _document_region(child)
         rendered = _render_block(child, context)
         if _preserves_trailing_spacing(child):
@@ -149,17 +134,17 @@ def _document_region(node):
         tag_name = node.name.lower()
         if tag_name == "h1":
             return "title"
-        if _has_class(node, "notice-top"):
+        if has_class(node, "notice-top"):
             return "preface"
         if node.get("id") == "legal-code-body":
             return "body"
-        if _has_class(node, "notice-bottom"):
+        if has_class(node, "notice-bottom"):
             return "footer"
     return "other"
 
 
 def _render_block(node, context, indent=0):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
         return _wrap_text(_clean_inline(str(node)), indent=indent)
@@ -171,17 +156,17 @@ def _render_block(node, context, indent=0):
         return ""
     if _is_skipped_notice_heading(node):
         return ""
-    if tag_name in _HEADING_TAGS:
+    if tag_name in HEADING_TAGS:
         return _wrap_text(_render_inline_children(node), indent=indent)
     if tag_name == "p":
         return _wrap_text(_render_inline_children(node), indent=indent)
-    if tag_name in _LIST_TAGS:
+    if tag_name in LIST_TAGS:
         return _render_list(node, context, indent=indent)
     if node.get("id") == "legal-code-body":
         return _render_legal_code_body(node, context, indent=indent)
     if node.get("id") == "about-cc-and-license":
         return _render_about_cc_and_license(node, context, indent=indent)
-    if _has_direct_block_child(node):
+    if has_direct_block_child(node):
         return _render_block_children(node, context, indent=indent)
     return _wrap_text(_render_inline_children(node), indent=indent)
 
@@ -232,7 +217,7 @@ def _legal_code_body_groups(node):
             groups.append((current_is_section, current_group))
             current_group = []
 
-    for child in _non_ignorable_children(node):
+    for child in non_ignorable_children(node):
         if _is_legal_section_heading(child):
             flush_group()
             current_group = [child]
@@ -246,7 +231,7 @@ def _legal_code_body_groups(node):
 def _render_about_cc_and_license(node, context, indent=0):
     chunks = []
     ordinary_nodes = []
-    children = _non_ignorable_children(node)
+    children = non_ignorable_children(node)
     index = 0
 
     def flush_ordinary_nodes():
@@ -284,7 +269,7 @@ def _render_about_cc_and_license(node, context, indent=0):
 
 def _is_notice_aside_heading(node):
     return (
-        _is_tag(node, "h3")
+        is_tag(node, "h3")
         and _NOTICE_ASIDE_CLASSES.issubset(set(node.get("class", [])))
     )
 
@@ -324,7 +309,7 @@ def _render_notice_aside(nodes, context, indent=0):
 
 
 def _render_notice_aside_text(node, context):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
         return _clean_inline(str(node))
@@ -334,7 +319,7 @@ def _render_notice_aside_text(node, context):
     tag_name = node.name.lower()
     if tag_name in _IGNORED_TAGS:
         return ""
-    if not _has_direct_block_child(node):
+    if not has_direct_block_child(node):
         return _render_inline_children(node)
     return _clean_inline(_render_block(node, context))
 
@@ -342,7 +327,7 @@ def _render_notice_aside_text(node, context):
 def _render_list(list_tag, context, indent=0):
     rendered_items = []
     is_ordered = list_tag.name.lower() == "ol"
-    list_items = _direct_children(list_tag, "li")
+    list_items = direct_children(list_tag, "li")
     start = _get_start(list_tag, len(list_items))
     for offset, list_item in enumerate(list_items):
         if is_ordered:
@@ -400,13 +385,13 @@ def _render_list_item_chunks(list_item, context, content_indent):
         if content:
             chunks.append((_LIST_CHUNK_TEXT, content))
 
-    for child in _non_ignorable_children(list_item):
+    for child in non_ignorable_children(list_item):
         if isinstance(child, Tag) and child.name.lower() == "div":
             flush_inline_nodes()
             chunks.extend(
                 _render_list_item_chunks(child, context, content_indent)
             )
-        elif isinstance(child, Tag) and child.name.lower() in _LIST_TAGS:
+        elif isinstance(child, Tag) and child.name.lower() in LIST_TAGS:
             flush_inline_nodes()
             rendered = _strip_rendered(
                 _render_list(child, context, indent=content_indent)
@@ -415,7 +400,7 @@ def _render_list_item_chunks(list_item, context, content_indent):
                 chunks.append((_LIST_CHUNK_RENDERED, rendered))
         elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
             flush_inline_nodes()
-            if child.name.lower() == "p" and not _has_direct_block_child(
+            if child.name.lower() == "p" and not has_direct_block_child(
                 child
             ):
                 rendered = _render_inline_children(child)
@@ -520,7 +505,7 @@ def _render_inline_nodes(nodes):
 
 
 def _render_inline(node):
-    if _is_ignorable(node):
+    if is_ignorable(node):
         return ""
     if isinstance(node, NavigableString):
         return str(node)
@@ -539,9 +524,9 @@ def _render_inline(node):
 
     if tag_name == "a":
         href = node.get("href")
-        display_url = _display_link_url(href)
+        display_url = display_link_url(href)
         if display_url:
-            label_url = _display_link_label_url(content)
+            label_url = display_link_label_url(content)
             if label_url == display_url:
                 return display_url
             label = content.rstrip(".!?")
@@ -554,58 +539,6 @@ def _render_inline(node):
 
 def _render_inline_children(node):
     return _render_inline_nodes(node.children)
-
-
-def _display_link_url(href):
-    if not href:
-        return ""
-    href = href.strip()
-    if not href or href.startswith("#"):
-        return ""
-    return _display_url(href)
-
-
-def _display_link_label_url(label):
-    label = label.strip().rstrip(".!?")
-    if not _looks_like_url(label):
-        return ""
-    return _display_url(label)
-
-
-def _display_url(value):
-    value = value.strip()
-    if not value:
-        return ""
-    if value.lower().startswith("mailto:"):
-        email = value[7:].split("?", 1)[0].split("#", 1)[0]
-        return email.strip()
-    if _EMAIL_LIKE_URL_RE.match(value):
-        return value
-
-    normalized = _absolute_http_url(value)
-    if not normalized:
-        return value.split("?", 1)[0].split("#", 1)[0]
-
-    parts = urlsplit(normalized)
-    path = parts.path or ""
-    display_url = f"{parts.netloc}{path}"
-    return display_url.rstrip("/") or parts.netloc
-
-
-def _absolute_http_url(value):
-    value = absolute_link_url(value)
-    parts = urlsplit(value)
-    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
-        return ""
-    return value
-
-
-def _looks_like_url(value):
-    return (
-        value.startswith(("http://", "https://", "//", "/", "mailto:"))
-        or bool(_DOMAIN_LIKE_URL_RE.match(value))
-        or bool(_EMAIL_LIKE_URL_RE.match(value))
-    )
 
 
 def _wrap_text(
@@ -656,53 +589,23 @@ def _clean_inline(value):
     value = value.replace("\u2019", "'")
     value = value.replace("\u201c", '"')
     value = value.replace("\u201d", '"')
-    value = re.sub(r"\s+", " ", value)
-    value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
-    value = re.sub(r"([(\[])\s+", r"\1", value)
-    return value.strip()
+    return clean_inline_spacing(value)
 
 
 def _restore_plain_text_tokens(value):
     return value.replace(EN_DASH_PLACEHOLDER, "--")
 
 
-def _has_direct_block_child(node):
-    return any(
-        isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS
-        for child in node.children
-    )
-
-
-def _non_ignorable_children(node):
-    return [child for child in node.children if not _is_ignorable(child)]
-
-
-def _direct_children(node, tag_name):
-    return [
-        child
-        for child in node.children
-        if isinstance(child, Tag) and child.name.lower() == tag_name
-    ]
-
-
-def _is_tag(node, tag_name):
-    return isinstance(node, Tag) and node.name.lower() == tag_name
-
-
-def _has_class(node, class_name):
-    return class_name in node.get("class", [])
-
-
 def _is_divider(node):
-    return _is_tag(node, "hr") and _has_class(node, "divider")
+    return is_tag(node, "hr") and has_class(node, "divider")
 
 
 def _is_legal_section_heading(node):
-    return _is_tag(node, "h3") and re.fullmatch(r"s\d+", node.get("id", ""))
+    return is_tag(node, "h3") and re.fullmatch(r"s\d+", node.get("id", ""))
 
 
 def _is_skipped_notice_heading(node):
-    if not _is_tag(node, "h2"):
+    if not is_tag(node, "h2"):
         return False
     parent = node.parent
     return (
@@ -722,11 +625,3 @@ def _has_bold_font_weight(node):
 
 def _preserves_trailing_spacing(node):
     return isinstance(node, Tag) and node.get("id") == "legal-code-body"
-
-
-def _is_ignorable(node):
-    if isinstance(node, Comment):
-        return True
-    if isinstance(node, NavigableString):
-        return not str(node).strip()
-    return False

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -10,6 +10,8 @@ PLAIN_TEXT_LINE_LENGTH = 71
 PLAIN_TEXT_SEPARATOR = "=" * PLAIN_TEXT_LINE_LENGTH
 LIST_INDENT = 5
 LIST_MARKER_WIDTH = 3
+NOTICE_ASIDE_INDENT = 5
+EN_DASH_PLACEHOLDER = "\ue000\ue001"
 
 BLOCK_TAGS = {
     "article",
@@ -51,6 +53,7 @@ def legal_code_html_to_plain_text(html):
         plain_text = _render_block(root).strip("\n")
     if not plain_text:
         return ""
+    plain_text = _restore_plain_text_tokens(plain_text)
     return f"{plain_text}\n"
 
 
@@ -113,28 +116,106 @@ def _render_block(node, indent=0):
         return _wrap_text(_render_inline_children(node), indent=indent)
     if tag_name in {"ol", "ul"}:
         return _render_list(node, indent=indent)
+    if node.get("id") == "about-cc-and-license":
+        return _render_about_cc_and_license(node, indent=indent)
     if _has_direct_block_child(node):
         return _render_block_children(node, indent=indent)
     return _wrap_text(_render_inline_children(node), indent=indent)
 
 
 def _render_block_children(node, indent=0):
+    return _render_block_nodes(node.children, indent=indent)
+
+
+def _render_block_nodes(nodes, indent=0):
     chunks = []
-    for child in node.children:
+    for child in nodes:
         rendered = _render_block(child, indent=indent).strip("\n")
         if rendered.strip():
             chunks.append(rendered)
     return "\n\n".join(chunks)
 
 
+def _render_about_cc_and_license(node, indent=0):
+    chunks = []
+    for after_divider, group in _divider_groups(node):
+        if not group:
+            continue
+        if after_divider and _is_tag(group[0], "h3"):
+            rendered = _render_notice_aside(group, indent=indent)
+        else:
+            rendered = _render_block_nodes(group, indent=indent)
+        rendered = rendered.strip("\n")
+        if rendered.strip():
+            chunks.append(rendered)
+    return "\n\n".join(chunks)
+
+
+def _divider_groups(node):
+    groups = [[False, []]]
+    for child in node.children:
+        if _is_ignorable(child):
+            continue
+        if _is_divider(child):
+            groups.append([True, []])
+        else:
+            groups[-1][1].append(child)
+    return groups
+
+
+def _render_notice_aside(nodes, indent=0):
+    heading = _render_inline_children(nodes[0])
+    if not heading:
+        return _render_block_nodes(nodes[1:], indent=indent)
+
+    prefix = heading if heading.endswith(":") else f"{heading}:"
+    content = " ".join(
+        part
+        for part in (
+            _render_notice_aside_text(node) for node in nodes[1:]
+        )
+        if part
+    )
+    value = f"{prefix} {content}" if content else prefix
+    aside_indent = " " * (indent + NOTICE_ASIDE_INDENT)
+    return _wrap_text(
+        value,
+        initial_indent=aside_indent,
+        subsequent_indent=aside_indent,
+        width=PLAIN_TEXT_LINE_LENGTH - NOTICE_ASIDE_INDENT,
+    )
+
+
+def _render_notice_aside_text(node):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return _clean_inline(str(node))
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name in {"script", "style", "hr"}:
+        return ""
+    if not _has_direct_block_child(node):
+        return _render_inline_children(node)
+    return _clean_inline(_render_block(node))
+
+
 def _render_list(list_tag, indent=0):
     rendered_items = []
+    is_ordered = list_tag.name.lower() == "ol"
     list_items = _direct_children(list_tag, "li")
     start = _get_start(list_tag, len(list_items))
     for offset, list_item in enumerate(list_items):
-        number = start - offset if _is_reversed(list_tag) else start + offset
-        marker = _get_list_marker(list_tag, number)
-        prefix = f"{' ' * indent}{_format_marker(marker)}"
+        if is_ordered:
+            number = (
+                start - offset if _is_reversed(list_tag) else start + offset
+            )
+            marker = _get_list_marker(list_tag, number)
+            prefix = f"{' ' * indent}{_format_marker(marker)}"
+        else:
+            prefix = f"{' ' * indent}{_format_unordered_marker()}"
         content_indent = max(indent + LIST_INDENT, len(prefix))
         chunks = _render_list_item_chunks(list_item, content_indent)
         if not chunks:
@@ -143,7 +224,7 @@ def _render_list(list_tag, indent=0):
             rendered_items.append(
                 "\n".join(_render_list_item(prefix, content_indent, chunks))
             )
-    separator = "\n\n" if list_tag.name.lower() == "ol" else "\n"
+    separator = "\n\n" if is_ordered else "\n"
     return separator.join(rendered_items)
 
 
@@ -213,6 +294,10 @@ def _format_marker(marker):
     return f"{marker}. "
 
 
+def _format_unordered_marker():
+    return f"{'-'.rjust(LIST_INDENT - 1)} "
+
+
 def _get_start(list_tag, list_length):
     if _is_reversed(list_tag):
         default = list_length
@@ -229,9 +314,6 @@ def _is_reversed(list_tag):
 
 
 def _get_list_marker(list_tag, number):
-    if list_tag.name.lower() == "ul":
-        return "-"
-
     list_type = list_tag.get("type", "1")
     if list_type in {"1", ""}:
         return str(number)
@@ -326,6 +408,7 @@ def _wrap_text(
     indent=0,
     initial_indent=None,
     subsequent_indent=None,
+    width=PLAIN_TEXT_LINE_LENGTH,
 ):
     if not value:
         return ""
@@ -335,19 +418,24 @@ def _wrap_text(
         subsequent_indent = " " * indent
     return textwrap.fill(
         value,
-        width=PLAIN_TEXT_LINE_LENGTH,
+        width=width,
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         break_long_words=False,
-        break_on_hyphens=False,
+        break_on_hyphens=True,
     )
 
 
 def _clean_inline(value):
+    value = value.replace("\u2013", EN_DASH_PLACEHOLDER)
     value = re.sub(r"\s+", " ", value)
     value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
     value = re.sub(r"([(\[])\s+", r"\1", value)
     return value.strip()
+
+
+def _restore_plain_text_tokens(value):
+    return value.replace(EN_DASH_PLACEHOLDER, "--")
 
 
 def _has_direct_block_child(node):
@@ -365,8 +453,16 @@ def _direct_children(node, tag_name):
     ]
 
 
+def _is_tag(node, tag_name):
+    return isinstance(node, Tag) and node.name.lower() == tag_name
+
+
 def _has_class(node, class_name):
     return class_name in node.get("class", [])
+
+
+def _is_divider(node):
+    return _is_tag(node, "hr") and _has_class(node, "divider")
 
 
 def _is_ignorable(node):

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -268,13 +268,20 @@ def _render_list(list_tag, indent=0):
             rendered_items.append(
                 "\n".join(_render_list_item(prefix, content_indent, chunks))
             )
-    separator = "\n\n" if is_ordered else "\n"
-    return separator.join(rendered_items)
+    return "\n\n".join(rendered_items)
 
 
 def _render_list_item(prefix, content_indent, chunks):
     lines = []
+    previous_kind = None
     for index, (kind, content) in enumerate(chunks):
+        if (
+            index > 0
+            and (kind == "block" or previous_kind == "block")
+            and lines
+            and lines[-1] != ""
+        ):
+            lines.append("")
         if kind == "text":
             if index == 0:
                 rendered = _wrap_text(
@@ -289,6 +296,7 @@ def _render_list_item(prefix, content_indent, chunks):
             if index == 0:
                 lines.append(prefix.rstrip())
             lines.extend(content.splitlines())
+        previous_kind = kind
     return lines
 
 

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -273,19 +273,10 @@ def _render_list(list_tag, indent=0):
 
 def _render_list_item(prefix, content_indent, chunks):
     lines = []
-    previous_kind = None
     for index, (kind, content) in enumerate(chunks):
-        if (
-            index > 0
-            and (
-                _is_list_item_block_like(kind)
-                or _is_list_item_block_like(previous_kind)
-            )
-            and lines
-            and lines[-1] != ""
-        ):
+        if index > 0 and lines and lines[-1] != "":
             lines.append("")
-        if kind in {"text", "paragraph"}:
+        if kind == "text":
             if index == 0:
                 rendered = _wrap_text(
                     content,
@@ -295,16 +286,13 @@ def _render_list_item(prefix, content_indent, chunks):
             else:
                 rendered = _wrap_text(content, indent=content_indent)
             lines.extend(rendered.splitlines())
-        else:
+        elif kind == "rendered":
             if index == 0:
                 lines.append(prefix.rstrip())
             lines.extend(content.splitlines())
-        previous_kind = kind
+        else:
+            raise PlainTextRenderError(f"Unknown list item chunk kind: {kind}")
     return lines
-
-
-def _is_list_item_block_like(kind):
-    return kind in {"block", "paragraph"}
 
 
 def _render_list_item_chunks(list_item, content_indent):
@@ -326,7 +314,7 @@ def _render_list_item_chunks(list_item, content_indent):
             flush_inline_nodes()
             rendered = _render_list(child, indent=content_indent).strip("\n")
             if rendered.strip():
-                chunks.append(("block", rendered))
+                chunks.append(("rendered", rendered))
         elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
             flush_inline_nodes()
             if child.name.lower() == "p" and not _has_direct_block_child(
@@ -334,13 +322,13 @@ def _render_list_item_chunks(list_item, content_indent):
             ):
                 rendered = _render_inline_children(child)
                 if rendered:
-                    chunks.append(("paragraph", rendered))
+                    chunks.append(("text", rendered))
             else:
                 rendered = _render_block(
                     child, indent=content_indent
                 ).strip("\n")
                 if rendered.strip():
-                    chunks.append(("block", rendered))
+                    chunks.append(("rendered", rendered))
         else:
             inline_nodes.append(child)
     flush_inline_nodes()

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -277,12 +277,15 @@ def _render_list_item(prefix, content_indent, chunks):
     for index, (kind, content) in enumerate(chunks):
         if (
             index > 0
-            and (kind == "block" or previous_kind == "block")
+            and (
+                _is_list_item_block_like(kind)
+                or _is_list_item_block_like(previous_kind)
+            )
             and lines
             and lines[-1] != ""
         ):
             lines.append("")
-        if kind == "text":
+        if kind in {"text", "paragraph"}:
             if index == 0:
                 rendered = _wrap_text(
                     content,
@@ -298,6 +301,10 @@ def _render_list_item(prefix, content_indent, chunks):
             lines.extend(content.splitlines())
         previous_kind = kind
     return lines
+
+
+def _is_list_item_block_like(kind):
+    return kind in {"block", "paragraph"}
 
 
 def _render_list_item_chunks(list_item, content_indent):
@@ -327,7 +334,7 @@ def _render_list_item_chunks(list_item, content_indent):
             ):
                 rendered = _render_inline_children(child)
                 if rendered:
-                    chunks.append(("text", rendered))
+                    chunks.append(("paragraph", rendered))
             else:
                 rendered = _render_block(
                     child, indent=content_indent

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -12,6 +12,10 @@ LIST_INDENT = 5
 LIST_MARKER_WIDTH = 3
 NOTICE_ASIDE_INDENT = 5
 EN_DASH_PLACEHOLDER = "\ue000\ue001"
+SECTION_REFERENCE_RE = re.compile(
+    r"^(\d+)((?:\([A-Za-z0-9]+\))+)([.,;:!?]*)$"
+)
+SECTION_REFERENCE_PART_RE = re.compile(r"\([A-Za-z0-9]+\)")
 
 BLOCK_TAGS = {
     "article",
@@ -33,6 +37,16 @@ BLOCK_TAGS = {
 
 class PlainTextRenderError(ValueError):
     pass
+
+
+class PlainTextWrapper(textwrap.TextWrapper):
+    def _split(self, text):
+        chunks = super()._split(text)
+        return [
+            part
+            for chunk in chunks
+            for part in _split_section_reference_chunk(chunk)
+        ]
 
 
 def legal_code_html_to_plain_text(html):
@@ -467,14 +481,26 @@ def _wrap_text(
         initial_indent = " " * indent
     if subsequent_indent is None:
         subsequent_indent = " " * indent
-    return textwrap.fill(
-        value,
+    wrapper = PlainTextWrapper(
         width=width,
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         break_long_words=False,
         break_on_hyphens=True,
     )
+    return wrapper.fill(value)
+
+
+def _split_section_reference_chunk(chunk):
+    match = SECTION_REFERENCE_RE.fullmatch(chunk)
+    if not match:
+        return [chunk]
+
+    section, parenthetical_refs, trailing_punctuation = match.groups()
+    parts = [section, *SECTION_REFERENCE_PART_RE.findall(parenthetical_refs)]
+    if trailing_punctuation:
+        parts[-1] = f"{parts[-1]}{trailing_punctuation}"
+    return parts
 
 
 def _clean_inline(value):

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -6,7 +6,7 @@ import textwrap
 from bs4 import BeautifulSoup, NavigableString, Tag
 from bs4.element import Comment
 
-PLAIN_TEXT_LINE_LENGTH = 70
+PLAIN_TEXT_LINE_LENGTH = 71
 PLAIN_TEXT_SEPARATOR = "=" * PLAIN_TEXT_LINE_LENGTH
 LIST_INDENT = 5
 LIST_MARKER_WIDTH = 3

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -329,6 +329,8 @@ def _render_list_item_chunks(list_item, content_indent):
         else:
             inline_nodes.append(child)
     flush_inline_nodes()
+    if _has_bold_font_weight(list_item):
+        chunks = [(kind, content.upper()) for kind, content in chunks]
     return chunks
 
 
@@ -432,6 +434,8 @@ def _render_inline(node):
     content = _render_inline_children(node)
     if not content:
         return ""
+    if _has_bold_font_weight(node):
+        content = content.upper()
 
     if tag_name == "a":
         href = node.get("href")
@@ -472,6 +476,9 @@ def _wrap_text(
 
 def _clean_inline(value):
     value = value.replace("\u2013", EN_DASH_PLACEHOLDER)
+    value = value.replace("\u2019", "'")
+    value = value.replace("\u201c", '"')
+    value = value.replace("\u201d", '"')
     value = re.sub(r"\s+", " ", value)
     value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
     value = re.sub(r"([(\[])\s+", r"\1", value)
@@ -521,6 +528,15 @@ def _is_skipped_notice_heading(node):
         "notice-about-licenses-and-cc",
         "notice-about-cc-and-trademark",
     }
+
+
+def _has_bold_font_weight(node):
+    if not isinstance(node, Tag):
+        return False
+    style = node.get("style", "")
+    return bool(
+        re.search(r"(?:^|;)\s*font-weight\s*:\s*bold\s*(?:;|$)", style, re.I)
+    )
 
 
 def _preserves_trailing_spacing(node):

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -196,29 +196,61 @@ def _legal_code_body_groups(node):
 
 def _render_about_cc_and_license(node, indent=0):
     chunks = []
-    for after_divider, group in _divider_groups(node):
-        if not group:
-            continue
-        if after_divider and _is_tag(group[0], "h3"):
-            rendered = _render_notice_aside(group, indent=indent)
-        else:
-            rendered = _render_block_nodes(group, indent=indent)
+    ordinary_nodes = []
+    children = [child for child in node.children if not _is_ignorable(child)]
+    index = 0
+
+    def flush_ordinary_nodes():
+        if not ordinary_nodes:
+            return
+        rendered = _render_block_nodes(ordinary_nodes, indent=indent)
         rendered = rendered.strip("\n")
         if rendered.strip():
             chunks.append(rendered)
+        ordinary_nodes.clear()
+
+    while index < len(children):
+        child = children[index]
+        if _is_notice_aside_heading(child):
+            flush_ordinary_nodes()
+            notice_nodes = [child]
+            index += 1
+            while index < len(children) and not _is_notice_aside_terminator(
+                children[index]
+            ):
+                notice_nodes.append(children[index])
+                index += 1
+            rendered = _render_notice_aside(notice_nodes, indent=indent)
+            rendered = rendered.strip("\n")
+            if rendered.strip():
+                chunks.append(rendered)
+            continue
+        if not _is_divider(child):
+            ordinary_nodes.append(child)
+        index += 1
+
+    flush_ordinary_nodes()
     return "\n\n".join(chunks)
 
 
-def _divider_groups(node):
-    groups = [[False, []]]
-    for child in node.children:
-        if _is_ignorable(child):
-            continue
-        if _is_divider(child):
-            groups.append([True, []])
-        else:
-            groups[-1][1].append(child)
-    return groups
+def _is_notice_aside_heading(node):
+    return (
+        _is_tag(node, "h3")
+        and _has_class(node, "level")
+        and _has_class(node, "is-vcentered")
+        and _has_class(node, "b-header")
+    )
+
+
+def _is_notice_aside_terminator(node):
+    return _is_divider(node) or _is_heading_at_or_above(node, level=3)
+
+
+def _is_heading_at_or_above(node, level):
+    if not isinstance(node, Tag):
+        return False
+    match = re.fullmatch(r"h([1-6])", node.name.lower())
+    return bool(match and int(match.group(1)) <= level)
 
 
 def _render_notice_aside(nodes, indent=0):

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -2,10 +2,14 @@
 from dataclasses import dataclass
 import re
 import textwrap
+from urllib.parse import urlsplit
 
 # Third-party
 from bs4 import BeautifulSoup, NavigableString, Tag
 from bs4.element import Comment
+
+# First-party/Local
+from legal_tools.link_utils import absolute_link_url
 
 PLAIN_TEXT_LINE_LENGTH = 71
 PLAIN_TEXT_SEPARATOR = "=" * PLAIN_TEXT_LINE_LENGTH
@@ -23,6 +27,12 @@ _LIST_TAGS = {"ol", "ul"}
 _LIST_CHUNK_TEXT = "text"
 _LIST_CHUNK_RENDERED = "rendered"
 _NOTICE_ASIDE_CLASSES = {"level", "is-vcentered", "b-header"}
+_DOMAIN_LIKE_URL_RE = re.compile(
+    r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?(?=[/?#]|$)"
+)
+_EMAIL_LIKE_URL_RE = re.compile(
+    r"^[^\s@]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
+)
 _SKIPPED_NOTICE_HEADING_PARENT_IDS = {
     "notice-about-licenses-and-cc",
     "notice-about-cc-and-trademark",
@@ -529,16 +539,73 @@ def _render_inline(node):
 
     if tag_name == "a":
         href = node.get("href")
-        if href and not href.startswith("#"):
-            if content[-1] in ".!?":
-                return f"{content} {href}"
-            return f"{content}: {href}"
+        display_url = _display_link_url(href)
+        if display_url:
+            label_url = _display_link_label_url(content)
+            if label_url == display_url:
+                return display_url
+            label = content.rstrip(".!?")
+            if label.endswith(":"):
+                return f"{label} {display_url}"
+            return f"{label}: {display_url}"
         return content
     return content
 
 
 def _render_inline_children(node):
     return _render_inline_nodes(node.children)
+
+
+def _display_link_url(href):
+    if not href:
+        return ""
+    href = href.strip()
+    if not href or href.startswith("#"):
+        return ""
+    return _display_url(href)
+
+
+def _display_link_label_url(label):
+    label = label.strip().rstrip(".!?")
+    if not _looks_like_url(label):
+        return ""
+    return _display_url(label)
+
+
+def _display_url(value):
+    value = value.strip()
+    if not value:
+        return ""
+    if value.lower().startswith("mailto:"):
+        email = value[7:].split("?", 1)[0].split("#", 1)[0]
+        return email.strip()
+    if _EMAIL_LIKE_URL_RE.match(value):
+        return value
+
+    normalized = _absolute_http_url(value)
+    if not normalized:
+        return value.split("?", 1)[0].split("#", 1)[0]
+
+    parts = urlsplit(normalized)
+    path = parts.path or ""
+    display_url = f"{parts.netloc}{path}"
+    return display_url.rstrip("/") or parts.netloc
+
+
+def _absolute_http_url(value):
+    value = absolute_link_url(value)
+    parts = urlsplit(value)
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        return ""
+    return value
+
+
+def _looks_like_url(value):
+    return (
+        value.startswith(("http://", "https://", "//", "/", "mailto:"))
+        or bool(_DOMAIN_LIKE_URL_RE.match(value))
+        or bool(_EMAIL_LIKE_URL_RE.match(value))
+    )
 
 
 def _wrap_text(

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -1,0 +1,377 @@
+# Standard library
+import re
+import textwrap
+
+# Third-party
+from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4.element import Comment
+
+PLAIN_TEXT_LINE_LENGTH = 70
+PLAIN_TEXT_SEPARATOR = "=" * PLAIN_TEXT_LINE_LENGTH
+LIST_INDENT = 5
+LIST_MARKER_WIDTH = 3
+
+BLOCK_TAGS = {
+    "article",
+    "blockquote",
+    "div",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "li",
+    "ol",
+    "p",
+    "section",
+    "ul",
+}
+
+
+class PlainTextRenderError(ValueError):
+    pass
+
+
+def legal_code_html_to_plain_text(html):
+    """
+    Convert rendered legalcode document/body HTML to plain text.
+
+    The converter is legalcode-focused. It uses the same document regions that
+    HTML/CSS use for visual separation, and it renders ordered-list markers
+    explicitly because plain text has no list semantics.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    legal_code_document = soup.find(id="legal-code-document")
+    legal_code_body = soup.find(id="legal-code-body")
+    root = legal_code_document or legal_code_body or soup.body or soup
+    if legal_code_document:
+        plain_text = _render_document(root).strip("\n")
+    else:
+        plain_text = _render_block(root).strip("\n")
+    if not plain_text:
+        return ""
+    return f"{plain_text}\n"
+
+
+def _render_document(document):
+    sections = []
+    current_region = None
+    current_chunks = []
+
+    def flush_region():
+        nonlocal current_region, current_chunks
+        rendered = "\n\n".join(chunk for chunk in current_chunks if chunk)
+        if rendered:
+            sections.append(rendered)
+        current_region = None
+        current_chunks = []
+
+    for child in document.children:
+        if _is_ignorable(child):
+            continue
+        region = _document_region(child)
+        rendered = _render_block(child).strip("\n")
+        if not rendered.strip():
+            continue
+        if current_region is not None and region != current_region:
+            flush_region()
+        current_region = region
+        current_chunks.append(rendered)
+    flush_region()
+    return f"\n\n{PLAIN_TEXT_SEPARATOR}\n\n".join(sections)
+
+
+def _document_region(node):
+    if isinstance(node, Tag):
+        tag_name = node.name.lower()
+        if tag_name == "h1":
+            return "title"
+        if _has_class(node, "notice-top"):
+            return "preface"
+        if node.get("id") == "legal-code-body":
+            return "body"
+        if _has_class(node, "notice-bottom"):
+            return "footer"
+    return "other"
+
+
+def _render_block(node, indent=0):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return _wrap_text(_clean_inline(str(node)), indent=indent)
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name in {"script", "style", "hr"}:
+        return ""
+    if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+        return _wrap_text(_render_inline_children(node), indent=indent)
+    if tag_name == "p":
+        return _wrap_text(_render_inline_children(node), indent=indent)
+    if tag_name in {"ol", "ul"}:
+        return _render_list(node, indent=indent)
+    if _has_direct_block_child(node):
+        return _render_block_children(node, indent=indent)
+    return _wrap_text(_render_inline_children(node), indent=indent)
+
+
+def _render_block_children(node, indent=0):
+    chunks = []
+    for child in node.children:
+        rendered = _render_block(child, indent=indent).strip("\n")
+        if rendered.strip():
+            chunks.append(rendered)
+    return "\n\n".join(chunks)
+
+
+def _render_list(list_tag, indent=0):
+    rendered_items = []
+    list_items = _direct_children(list_tag, "li")
+    start = _get_start(list_tag, len(list_items))
+    for offset, list_item in enumerate(list_items):
+        number = start - offset if _is_reversed(list_tag) else start + offset
+        marker = _get_list_marker(list_tag, number)
+        prefix = f"{' ' * indent}{_format_marker(marker)}"
+        content_indent = max(indent + LIST_INDENT, len(prefix))
+        chunks = _render_list_item_chunks(list_item, content_indent)
+        if not chunks:
+            rendered_items.append(prefix.rstrip())
+        else:
+            rendered_items.append(
+                "\n".join(_render_list_item(prefix, content_indent, chunks))
+            )
+    separator = "\n\n" if list_tag.name.lower() == "ol" else "\n"
+    return separator.join(rendered_items)
+
+
+def _render_list_item(prefix, content_indent, chunks):
+    lines = []
+    for index, (kind, content) in enumerate(chunks):
+        if kind == "text":
+            if index == 0:
+                rendered = _wrap_text(
+                    content,
+                    initial_indent=prefix,
+                    subsequent_indent=" " * content_indent,
+                )
+            else:
+                rendered = _wrap_text(content, indent=content_indent)
+            lines.extend(rendered.splitlines())
+        else:
+            if index == 0:
+                lines.append(prefix.rstrip())
+            lines.extend(content.splitlines())
+    return lines
+
+
+def _render_list_item_chunks(list_item, content_indent):
+    chunks = []
+    inline_nodes = []
+
+    def flush_inline_nodes():
+        if not inline_nodes:
+            return
+        content = _render_inline_nodes(inline_nodes)
+        inline_nodes.clear()
+        if content:
+            chunks.append(("text", content))
+
+    for child in list_item.children:
+        if _is_ignorable(child):
+            continue
+        if isinstance(child, Tag) and child.name.lower() in {"ol", "ul"}:
+            flush_inline_nodes()
+            rendered = _render_list(child, indent=content_indent).strip("\n")
+            if rendered.strip():
+                chunks.append(("block", rendered))
+        elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
+            flush_inline_nodes()
+            if child.name.lower() == "p" and not _has_direct_block_child(
+                child
+            ):
+                rendered = _render_inline_children(child)
+                if rendered:
+                    chunks.append(("text", rendered))
+            else:
+                rendered = _render_block(
+                    child, indent=content_indent
+                ).strip("\n")
+                if rendered.strip():
+                    chunks.append(("block", rendered))
+        else:
+            inline_nodes.append(child)
+    flush_inline_nodes()
+    return chunks
+
+
+def _format_marker(marker):
+    if len(marker) <= LIST_MARKER_WIDTH:
+        marker = marker.rjust(LIST_MARKER_WIDTH)
+    return f"{marker}. "
+
+
+def _get_start(list_tag, list_length):
+    if _is_reversed(list_tag):
+        default = list_length
+    else:
+        default = 1
+    try:
+        return int(list_tag.get("start", default))
+    except ValueError:
+        return default
+
+
+def _is_reversed(list_tag):
+    return list_tag.name.lower() == "ol" and list_tag.has_attr("reversed")
+
+
+def _get_list_marker(list_tag, number):
+    if list_tag.name.lower() == "ul":
+        return "-"
+
+    list_type = list_tag.get("type", "1")
+    if list_type in {"1", ""}:
+        return str(number)
+    if list_type == "a":
+        return _alpha(number).lower()
+    if list_type == "A":
+        return _alpha(number).upper()
+    if list_type == "i":
+        return _roman(number).lower()
+    if list_type == "I":
+        return _roman(number).upper()
+    return str(number)
+
+
+def _alpha(number):
+    if number < 1:
+        raise PlainTextRenderError(
+            f"Alpha list marker requires positive number: {number}"
+        )
+    chars = []
+    while number > 0:
+        number -= 1
+        number, remainder = divmod(number, 26)
+        chars.append(chr(ord("a") + remainder))
+    return "".join(reversed(chars))
+
+
+def _roman(number):
+    if number < 1:
+        raise PlainTextRenderError(
+            f"Roman list marker requires positive number: {number}"
+        )
+    numerals = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+    result = []
+    for value, symbol in numerals:
+        while number >= value:
+            result.append(symbol)
+            number -= value
+    return "".join(result)
+
+
+def _render_inline_nodes(nodes):
+    return _clean_inline("".join(_render_inline(node) for node in nodes))
+
+
+def _render_inline(node):
+    if _is_ignorable(node):
+        return ""
+    if isinstance(node, NavigableString):
+        return str(node)
+    if not isinstance(node, Tag):
+        return ""
+
+    tag_name = node.name.lower()
+    if tag_name == "br":
+        return "\n"
+
+    content = _render_inline_children(node)
+    if not content:
+        return ""
+
+    if tag_name == "a":
+        href = node.get("href")
+        if href and not href.startswith("#"):
+            if content[-1] in ".!?":
+                return f"{content} {href}"
+            return f"{content}: {href}"
+        return content
+    return content
+
+
+def _render_inline_children(node):
+    return _render_inline_nodes(node.children)
+
+
+def _wrap_text(
+    value,
+    indent=0,
+    initial_indent=None,
+    subsequent_indent=None,
+):
+    if not value:
+        return ""
+    if initial_indent is None:
+        initial_indent = " " * indent
+    if subsequent_indent is None:
+        subsequent_indent = " " * indent
+    return textwrap.fill(
+        value,
+        width=PLAIN_TEXT_LINE_LENGTH,
+        initial_indent=initial_indent,
+        subsequent_indent=subsequent_indent,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
+def _clean_inline(value):
+    value = re.sub(r"\s+", " ", value)
+    value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
+    value = re.sub(r"([(\[])\s+", r"\1", value)
+    return value.strip()
+
+
+def _has_direct_block_child(node):
+    return any(
+        isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS
+        for child in node.children
+    )
+
+
+def _direct_children(node, tag_name):
+    return [
+        child
+        for child in node.children
+        if isinstance(child, Tag) and child.name.lower() == tag_name
+    ]
+
+
+def _has_class(node, class_name):
+    return class_name in node.get("class", [])
+
+
+def _is_ignorable(node):
+    if isinstance(node, Comment):
+        return True
+    if isinstance(node, NavigableString):
+        return not str(node).strip()
+    return False

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -363,7 +363,10 @@ def _render_list_item_chunks(list_item, content_indent):
             chunks.append((_LIST_CHUNK_TEXT, content))
 
     for child in _non_ignorable_children(list_item):
-        if isinstance(child, Tag) and child.name.lower() in _LIST_TAGS:
+        if isinstance(child, Tag) and child.name.lower() == "div":
+            flush_inline_nodes()
+            chunks.extend(_render_list_item_chunks(child, content_indent))
+        elif isinstance(child, Tag) and child.name.lower() in _LIST_TAGS:
             flush_inline_nodes()
             rendered = _strip_rendered(
                 _render_list(child, indent=content_indent)

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -12,10 +12,21 @@ LIST_INDENT = 5
 LIST_MARKER_WIDTH = 3
 NOTICE_ASIDE_INDENT = 5
 EN_DASH_PLACEHOLDER = "\ue000\ue001"
-SECTION_REFERENCE_RE = re.compile(
-    r"^(\d+)((?:\([A-Za-z0-9]+\))+)([.,;:!?]*)$"
+_SECTION_REFERENCE_RE = re.compile(
+    r"^(\d+)((?:\([A-Za-z0-9]+\))+)(-(?:\([A-Za-z0-9]+\))+)?"
+    r"([.,;:!?]*)$"
 )
-SECTION_REFERENCE_PART_RE = re.compile(r"\([A-Za-z0-9]+\)")
+_SECTION_REFERENCE_PART_RE = re.compile(r"\([A-Za-z0-9]+\)")
+_IGNORED_TAGS = {"script", "style", "hr"}
+_HEADING_TAGS = {"h1", "h2", "h3", "h4", "h5", "h6"}
+_LIST_TAGS = {"ol", "ul"}
+_LIST_CHUNK_TEXT = "text"
+_LIST_CHUNK_RENDERED = "rendered"
+_NOTICE_ASIDE_CLASSES = {"level", "is-vcentered", "b-header"}
+_SKIPPED_NOTICE_HEADING_PARENT_IDS = {
+    "notice-about-licenses-and-cc",
+    "notice-about-cc-and-trademark",
+}
 
 BLOCK_TAGS = {
     "article",
@@ -39,7 +50,7 @@ class PlainTextRenderError(ValueError):
     pass
 
 
-class PlainTextWrapper(textwrap.TextWrapper):
+class _PlainTextWrapper(textwrap.TextWrapper):
     def _split(self, text):
         chunks = super()._split(text)
         return [
@@ -84,9 +95,7 @@ def _render_document(document):
         current_region = None
         current_chunks = []
 
-    for child in document.children:
-        if _is_ignorable(child):
-            continue
+    for child in _non_ignorable_children(document):
         region = _document_region(child)
         rendered = _render_block(child)
         if _preserves_trailing_spacing(child):
@@ -126,15 +135,15 @@ def _render_block(node, indent=0):
         return ""
 
     tag_name = node.name.lower()
-    if tag_name in {"script", "style", "hr"}:
+    if tag_name in _IGNORED_TAGS:
         return ""
     if _is_skipped_notice_heading(node):
         return ""
-    if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+    if tag_name in _HEADING_TAGS:
         return _wrap_text(_render_inline_children(node), indent=indent)
     if tag_name == "p":
         return _wrap_text(_render_inline_children(node), indent=indent)
-    if tag_name in {"ol", "ul"}:
+    if tag_name in _LIST_TAGS:
         return _render_list(node, indent=indent)
     if node.get("id") == "legal-code-body":
         return _render_legal_code_body(node, indent=indent)
@@ -152,16 +161,24 @@ def _render_block_children(node, indent=0):
 def _render_block_nodes(nodes, indent=0):
     chunks = []
     for child in nodes:
-        rendered = _render_block(child, indent=indent).strip("\n")
-        if rendered.strip():
-            chunks.append(rendered)
+        _append_rendered(chunks, _render_block(child, indent=indent))
     return "\n\n".join(chunks)
+
+
+def _append_rendered(chunks, rendered):
+    rendered = _strip_rendered(rendered)
+    if rendered.strip():
+        chunks.append(rendered)
+
+
+def _strip_rendered(rendered):
+    return rendered.strip("\n")
 
 
 def _render_legal_code_body(node, indent=0):
     chunks = []
     for is_section, group in _legal_code_body_groups(node):
-        rendered = _render_block_nodes(group, indent=indent).strip("\n")
+        rendered = _strip_rendered(_render_block_nodes(group, indent=indent))
         if not rendered.strip():
             continue
         if is_section:
@@ -181,9 +198,7 @@ def _legal_code_body_groups(node):
             groups.append((current_is_section, current_group))
             current_group = []
 
-    for child in node.children:
-        if _is_ignorable(child):
-            continue
+    for child in _non_ignorable_children(node):
         if _is_legal_section_heading(child):
             flush_group()
             current_group = [child]
@@ -197,16 +212,14 @@ def _legal_code_body_groups(node):
 def _render_about_cc_and_license(node, indent=0):
     chunks = []
     ordinary_nodes = []
-    children = [child for child in node.children if not _is_ignorable(child)]
+    children = _non_ignorable_children(node)
     index = 0
 
     def flush_ordinary_nodes():
         if not ordinary_nodes:
             return
         rendered = _render_block_nodes(ordinary_nodes, indent=indent)
-        rendered = rendered.strip("\n")
-        if rendered.strip():
-            chunks.append(rendered)
+        _append_rendered(chunks, rendered)
         ordinary_nodes.clear()
 
     while index < len(children):
@@ -221,9 +234,7 @@ def _render_about_cc_and_license(node, indent=0):
                 notice_nodes.append(children[index])
                 index += 1
             rendered = _render_notice_aside(notice_nodes, indent=indent)
-            rendered = rendered.strip("\n")
-            if rendered.strip():
-                chunks.append(rendered)
+            _append_rendered(chunks, rendered)
             continue
         if not _is_divider(child):
             ordinary_nodes.append(child)
@@ -236,9 +247,7 @@ def _render_about_cc_and_license(node, indent=0):
 def _is_notice_aside_heading(node):
     return (
         _is_tag(node, "h3")
-        and _has_class(node, "level")
-        and _has_class(node, "is-vcentered")
-        and _has_class(node, "b-header")
+        and _NOTICE_ASIDE_CLASSES.issubset(set(node.get("class", [])))
     )
 
 
@@ -285,7 +294,7 @@ def _render_notice_aside_text(node):
         return ""
 
     tag_name = node.name.lower()
-    if tag_name in {"script", "style", "hr"}:
+    if tag_name in _IGNORED_TAGS:
         return ""
     if not _has_direct_block_child(node):
         return _render_inline_children(node)
@@ -322,7 +331,7 @@ def _render_list_item(prefix, content_indent, chunks):
     for index, (kind, content) in enumerate(chunks):
         if index > 0 and lines and lines[-1] != "":
             lines.append("")
-        if kind == "text":
+        if kind == _LIST_CHUNK_TEXT:
             if index == 0:
                 rendered = _wrap_text(
                     content,
@@ -332,7 +341,7 @@ def _render_list_item(prefix, content_indent, chunks):
             else:
                 rendered = _wrap_text(content, indent=content_indent)
             lines.extend(rendered.splitlines())
-        elif kind == "rendered":
+        elif kind == _LIST_CHUNK_RENDERED:
             if index == 0:
                 lines.append(prefix.rstrip())
             lines.extend(content.splitlines())
@@ -351,16 +360,16 @@ def _render_list_item_chunks(list_item, content_indent):
         content = _render_inline_nodes(inline_nodes)
         inline_nodes.clear()
         if content:
-            chunks.append(("text", content))
+            chunks.append((_LIST_CHUNK_TEXT, content))
 
-    for child in list_item.children:
-        if _is_ignorable(child):
-            continue
-        if isinstance(child, Tag) and child.name.lower() in {"ol", "ul"}:
+    for child in _non_ignorable_children(list_item):
+        if isinstance(child, Tag) and child.name.lower() in _LIST_TAGS:
             flush_inline_nodes()
-            rendered = _render_list(child, indent=content_indent).strip("\n")
+            rendered = _strip_rendered(
+                _render_list(child, indent=content_indent)
+            )
             if rendered.strip():
-                chunks.append(("rendered", rendered))
+                chunks.append((_LIST_CHUNK_RENDERED, rendered))
         elif isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS:
             flush_inline_nodes()
             if child.name.lower() == "p" and not _has_direct_block_child(
@@ -368,13 +377,13 @@ def _render_list_item_chunks(list_item, content_indent):
             ):
                 rendered = _render_inline_children(child)
                 if rendered:
-                    chunks.append(("text", rendered))
+                    chunks.append((_LIST_CHUNK_TEXT, rendered))
             else:
-                rendered = _render_block(
-                    child, indent=content_indent
-                ).strip("\n")
+                rendered = _strip_rendered(
+                    _render_block(child, indent=content_indent)
+                )
                 if rendered.strip():
-                    chunks.append(("rendered", rendered))
+                    chunks.append((_LIST_CHUNK_RENDERED, rendered))
         else:
             inline_nodes.append(child)
     flush_inline_nodes()
@@ -384,8 +393,11 @@ def _render_list_item_chunks(list_item, content_indent):
 
 
 def _format_marker(marker):
-    if len(marker) <= LIST_MARKER_WIDTH:
-        marker = marker.rjust(LIST_MARKER_WIDTH)
+    if len(marker) > LIST_MARKER_WIDTH:
+        raise PlainTextRenderError(
+            f"List marker exceeds {LIST_MARKER_WIDTH} characters: {marker}"
+        )
+    marker = marker.rjust(LIST_MARKER_WIDTH)
     return f"{marker}. "
 
 
@@ -513,7 +525,7 @@ def _wrap_text(
         initial_indent = " " * indent
     if subsequent_indent is None:
         subsequent_indent = " " * indent
-    wrapper = PlainTextWrapper(
+    wrapper = _PlainTextWrapper(
         width=width,
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
@@ -524,12 +536,20 @@ def _wrap_text(
 
 
 def _split_section_reference_chunk(chunk):
-    match = SECTION_REFERENCE_RE.fullmatch(chunk)
+    match = _SECTION_REFERENCE_RE.fullmatch(chunk)
     if not match:
         return [chunk]
 
-    section, parenthetical_refs, trailing_punctuation = match.groups()
-    parts = [section, *SECTION_REFERENCE_PART_RE.findall(parenthetical_refs)]
+    section, parenthetical_refs, range_refs, trailing_punctuation = (
+        match.groups()
+    )
+    parts = [
+        section,
+        *_SECTION_REFERENCE_PART_RE.findall(parenthetical_refs),
+    ]
+    if range_refs:
+        parts[-1] = f"{parts[-1]}-"
+        parts.extend(_SECTION_REFERENCE_PART_RE.findall(range_refs))
     if trailing_punctuation:
         parts[-1] = f"{parts[-1]}{trailing_punctuation}"
     return parts
@@ -555,6 +575,10 @@ def _has_direct_block_child(node):
         isinstance(child, Tag) and child.name.lower() in BLOCK_TAGS
         for child in node.children
     )
+
+
+def _non_ignorable_children(node):
+    return [child for child in node.children if not _is_ignorable(child)]
 
 
 def _direct_children(node, tag_name):
@@ -585,10 +609,10 @@ def _is_skipped_notice_heading(node):
     if not _is_tag(node, "h2"):
         return False
     parent = node.parent
-    return isinstance(parent, Tag) and parent.get("id") in {
-        "notice-about-licenses-and-cc",
-        "notice-about-cc-and-trademark",
-    }
+    return (
+        isinstance(parent, Tag)
+        and parent.get("id") in _SKIPPED_NOTICE_HEADING_PARENT_IDS
+    )
 
 
 def _has_bold_font_weight(node):

--- a/legal_tools/plaintext_utils.py
+++ b/legal_tools/plaintext_utils.py
@@ -74,7 +74,11 @@ def _render_document(document):
         if _is_ignorable(child):
             continue
         region = _document_region(child)
-        rendered = _render_block(child).strip("\n")
+        rendered = _render_block(child)
+        if _preserves_trailing_spacing(child):
+            rendered = rendered.lstrip("\n")
+        else:
+            rendered = rendered.strip("\n")
         if not rendered.strip():
             continue
         if current_region is not None and region != current_region:
@@ -110,12 +114,16 @@ def _render_block(node, indent=0):
     tag_name = node.name.lower()
     if tag_name in {"script", "style", "hr"}:
         return ""
+    if _is_skipped_notice_heading(node):
+        return ""
     if tag_name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
         return _wrap_text(_render_inline_children(node), indent=indent)
     if tag_name == "p":
         return _wrap_text(_render_inline_children(node), indent=indent)
     if tag_name in {"ol", "ul"}:
         return _render_list(node, indent=indent)
+    if node.get("id") == "legal-code-body":
+        return _render_legal_code_body(node, indent=indent)
     if node.get("id") == "about-cc-and-license":
         return _render_about_cc_and_license(node, indent=indent)
     if _has_direct_block_child(node):
@@ -134,6 +142,42 @@ def _render_block_nodes(nodes, indent=0):
         if rendered.strip():
             chunks.append(rendered)
     return "\n\n".join(chunks)
+
+
+def _render_legal_code_body(node, indent=0):
+    chunks = []
+    for is_section, group in _legal_code_body_groups(node):
+        rendered = _render_block_nodes(group, indent=indent).strip("\n")
+        if not rendered.strip():
+            continue
+        if is_section:
+            rendered = f"{rendered}\n"
+        chunks.append(rendered)
+    return "\n\n".join(chunks)
+
+
+def _legal_code_body_groups(node):
+    groups = []
+    current_group = []
+    current_is_section = False
+
+    def flush_group():
+        nonlocal current_group
+        if current_group:
+            groups.append((current_is_section, current_group))
+            current_group = []
+
+    for child in node.children:
+        if _is_ignorable(child):
+            continue
+        if _is_legal_section_heading(child):
+            flush_group()
+            current_group = [child]
+            current_is_section = True
+        else:
+            current_group.append(child)
+    flush_group()
+    return groups
 
 
 def _render_about_cc_and_license(node, indent=0):
@@ -463,6 +507,24 @@ def _has_class(node, class_name):
 
 def _is_divider(node):
     return _is_tag(node, "hr") and _has_class(node, "divider")
+
+
+def _is_legal_section_heading(node):
+    return _is_tag(node, "h3") and re.fullmatch(r"s\d+", node.get("id", ""))
+
+
+def _is_skipped_notice_heading(node):
+    if not _is_tag(node, "h2"):
+        return False
+    parent = node.parent
+    return isinstance(parent, Tag) and parent.get("id") in {
+        "notice-about-licenses-and-cc",
+        "notice-about-cc-and-trademark",
+    }
+
+
+def _preserves_trailing_spacing(node):
+    return isinstance(node, Tag) and node.get("id") == "legal-code-body"
 
 
 def _is_ignorable(node):

--- a/legal_tools/render_utils.py
+++ b/legal_tools/render_utils.py
@@ -1,0 +1,82 @@
+# Standard library
+import re
+
+# Third-party
+from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4.element import Comment
+
+TEXT_LINE_LENGTH = 71
+
+BLOCK_TAGS = frozenset(
+    {
+        "article",
+        "blockquote",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "li",
+        "ol",
+        "p",
+        "section",
+        "ul",
+    }
+)
+HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
+IGNORED_TAGS = frozenset({"script", "style"})
+LIST_TAGS = frozenset({"ol", "ul"})
+
+
+def legal_code_root(html):
+    soup = BeautifulSoup(html, "lxml")
+    return (
+        soup.find(id="legal-code-document")
+        or soup.find(id="legal-code-body")
+        or soup.body
+        or soup
+    )
+
+
+def clean_inline_spacing(value):
+    value = re.sub(r"\s+", " ", value)
+    value = re.sub(r"\s+([,.;:!?%)\]])", r"\1", value)
+    value = re.sub(r"([(\[])\s+", r"\1", value)
+    return value.strip()
+
+
+def direct_children(node, tag_name):
+    return [
+        child
+        for child in node.children
+        if isinstance(child, Tag) and child.name.lower() == tag_name
+    ]
+
+
+def has_class(node, class_name):
+    return class_name in node.get("class", [])
+
+
+def has_direct_block_child(node, block_tags=BLOCK_TAGS):
+    return any(
+        isinstance(child, Tag) and child.name.lower() in block_tags
+        for child in node.children
+    )
+
+
+def is_ignorable(node):
+    if isinstance(node, Comment):
+        return True
+    if isinstance(node, NavigableString):
+        return not str(node).strip()
+    return False
+
+
+def is_tag(node, tag_name):
+    return isinstance(node, Tag) and node.name.lower() == tag_name
+
+
+def non_ignorable_children(node):
+    return [child for child in node.children if not is_ignorable(child)]

--- a/legal_tools/tests/test_link_utils.py
+++ b/legal_tools/tests/test_link_utils.py
@@ -1,0 +1,75 @@
+# Third-party
+from django.test import SimpleTestCase
+
+# First-party/Local
+from legal_tools.link_utils import (
+    absolute_link_url,
+    display_link_label_url,
+    display_link_url,
+    markdown_link,
+    markdown_link_destination,
+)
+
+
+class LinkUtilsTest(SimpleTestCase):
+    def test_absolute_link_url(self):
+        self.assertEqual("#s1", absolute_link_url("#s1"))
+        self.assertEqual(
+            "https://creativecommons.org/policies/",
+            absolute_link_url("/policies/"),
+        )
+        self.assertEqual(
+            "https://creativecommons.org/compatiblelicenses",
+            absolute_link_url("//creativecommons.org/compatiblelicenses"),
+        )
+        self.assertEqual(
+            "https://example.test/path?x=1#part",
+            absolute_link_url("example.test/path?x=1#part"),
+        )
+        self.assertEqual(
+            "mailto:info@creativecommons.org",
+            absolute_link_url("mailto:info@creativecommons.org"),
+        )
+
+    def test_display_link_url(self):
+        self.assertEqual("", display_link_url("#s1"))
+        self.assertEqual(
+            "creativecommons.org/policies",
+            display_link_url("/policies/?x=1#license"),
+        )
+        self.assertEqual(
+            "creativecommons.org",
+            display_link_url("//creativecommons.org/"),
+        )
+        self.assertEqual(
+            "info@creativecommons.org",
+            display_link_url("mailto:info@creativecommons.org?subject=Hi"),
+        )
+
+    def test_display_link_label_url(self):
+        self.assertEqual(
+            "creativecommons.org/policies",
+            display_link_label_url("creativecommons.org/policies."),
+        )
+        self.assertEqual("", display_link_label_url("More information"))
+
+    def test_markdown_link_destination(self):
+        self.assertEqual("#s1", markdown_link_destination("#s1"))
+        self.assertEqual(
+            "<https://creativecommons.org/policies/some path(1)>",
+            markdown_link_destination("/policies/some path(1)"),
+        )
+        self.assertEqual(
+            "https://example.test/path?x=1#part",
+            markdown_link_destination("https://example.test/path?x=1#part"),
+        )
+        self.assertEqual(
+            "<https://example.test/a%3Cb%3E>",
+            markdown_link_destination("https://example.test/a<b>"),
+        )
+
+    def test_markdown_link_escapes_label(self):
+        self.assertEqual(
+            "[Policy \\[draft\\]](https://creativecommons.org/policies/)",
+            markdown_link("Policy [draft]", "/policies/"),
+        )

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -33,14 +33,14 @@ class MarkdownUtilsTest(SimpleTestCase):
             "<u>Adapted Material</u> means material described in "
             "[Section 1](#s1).\n\n"
             '<ol type="a">\n'
-            "<li>First item</li>\n"
-            "<li>\n"
-            "Second item\n"
-            '<ol type="i">\n'
-            "<li>Nested item</li>\n"
-            "<li>Second nested item</li>\n"
-            "</ol>\n"
-            "</li>\n"
+            "  <li>First item</li>\n"
+            "  <li>\n"
+            "    Second item\n"
+            '    <ol type="i">\n'
+            "      <li>Nested item</li>\n"
+            "      <li>Second nested item</li>\n"
+            "    </ol>\n"
+            "  </li>\n"
             "</ol>\n"
         )
 
@@ -73,7 +73,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertEqual(
             '<ol type="A">\n'
-            "<li><strong>Notice</strong> and <em>care</em> must be "
+            "  <li><strong>Notice</strong> and <em>care</em> must be "
             "retained.</li>\n"
             "</ol>\n",
             legal_code_html_to_markdown(html),
@@ -90,10 +90,56 @@ class MarkdownUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "<ol>\n"
-            "<li>First decimal item.</li>\n"
-            "<li>Second decimal item.</li>\n"
-            "</ol>\n",
+            "1. First decimal item.\n"
+            "2. Second decimal item.\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_unwraps_div_in_decimal_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>
+              <div><strong>Term</strong> means something.</div>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "1. **Term** means something.\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_unordered_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ul>
+            <li>First bullet.</li>
+            <li>Second bullet.</li>
+          </ul>
+        </div>
+        """
+
+        self.assertEqual(
+            "- First bullet.\n"
+            "- Second bullet.\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_ordered_list_start(self):
+        html = """
+        <div id="legal-code-body">
+          <ol start="3">
+            <li>Third decimal item.</li>
+            <li>Fourth decimal item.</li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "3. Third decimal item.\n"
+            "4. Fourth decimal item.\n",
             legal_code_html_to_markdown(html),
         )
 
@@ -113,7 +159,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertGreater(len(lines), 1)
         self.assertEqual(text, " ".join(lines))
-        self.assertTrue(all(len(line) <= 70 for line in lines))
+        self.assertTrue(all(len(line) <= 71 for line in lines))
 
     def test_legal_code_html_to_markdown_wraps_direct_text_nodes(self):
         text = (
@@ -132,7 +178,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertEqual("## Notice", lines[0])
         self.assertEqual(text, " ".join(lines[2:]))
-        self.assertTrue(all(len(line) <= 70 for line in lines))
+        self.assertTrue(all(len(line) <= 71 for line in lines))
 
     def test_legal_code_html_to_markdown_wraps_markdown_emphasis(self):
         html = """
@@ -149,7 +195,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertIn("**strong emphasis**", markdown)
         self.assertIn("*emphasis text*", markdown)
-        self.assertTrue(all(len(line) <= 70 for line in markdown.splitlines()))
+        self.assertTrue(all(len(line) <= 71 for line in markdown.splitlines()))
 
     def test_legal_code_html_to_markdown_wraps_html_list_items(self):
         text = (
@@ -168,12 +214,13 @@ class MarkdownUtilsTest(SimpleTestCase):
         lines = markdown.splitlines()
 
         self.assertEqual('<ol type="a">', lines[0])
-        self.assertEqual("<li>", lines[1])
-        self.assertEqual("</li>", lines[-2])
+        self.assertEqual("  <li>", lines[1])
+        self.assertEqual("  </li>", lines[-2])
         self.assertEqual("</ol>", lines[-1])
         self.assertNotIn("", lines)
-        self.assertEqual(text, " ".join(lines[2:-2]))
-        self.assertTrue(all(len(line) <= 70 for line in lines))
+        self.assertEqual(text, " ".join(line.strip() for line in lines[2:-2]))
+        self.assertTrue(all(line.startswith("    ") for line in lines[2:-2]))
+        self.assertTrue(all(len(line) <= 71 for line in lines))
 
     def test_legal_code_html_to_markdown_wraps_html_block_tags(self):
         text = (
@@ -182,7 +229,7 @@ class MarkdownUtilsTest(SimpleTestCase):
         )
         html = f"""
         <div id="legal-code-body">
-          <ol>
+          <ol type="a">
             <li><p>{text}</p></li>
           </ol>
         </div>
@@ -191,9 +238,55 @@ class MarkdownUtilsTest(SimpleTestCase):
         markdown = legal_code_html_to_markdown(html)
         lines = markdown.splitlines()
 
-        self.assertIn("<p>", lines)
-        self.assertIn("</p>", lines)
-        self.assertTrue(all(len(line) <= 70 for line in lines))
+        self.assertIn("    <p>", lines)
+        self.assertIn("    </p>", lines)
+        self.assertTrue(all(len(line) <= 71 for line in lines))
+
+    def test_legal_code_html_to_markdown_unwraps_div_in_html_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li>
+              <div><strong>Term</strong> means something.</div>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            '<ol type="a">\n'
+            "  <li><strong>Term</strong> means something.</li>\n"
+            "</ol>\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_unwraps_div_around_blocks(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li>
+              <div>
+                <p>Introductory paragraph.</p>
+                <ol type="i">
+                  <li>Nested item.</li>
+                </ol>
+              </div>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            '<ol type="a">\n'
+            "  <li>\n"
+            "    <p>Introductory paragraph.</p>\n"
+            '    <ol type="i">\n'
+            "      <li>Nested item.</li>\n"
+            "    </ol>\n"
+            "  </li>\n"
+            "</ol>\n",
+            legal_code_html_to_markdown(html),
+        )
 
     def test_legal_code_html_to_markdown_preserves_long_tokens(self):
         token = f"https://creativecommons.org/{'licensepath' * 9}"
@@ -245,13 +338,57 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertEqual(
             '<ol type="a">\n'
-            "<li>\n"
-            "Parent item\n"
-            "<ol>\n"
-            "<li>Nested decimal item.</li>\n"
-            "<li>Second nested decimal item.</li>\n"
-            "</ol>\n"
-            "</li>\n"
+            "  <li>\n"
+            "    Parent item\n"
+            "    <ol>\n"
+            "      <li>Nested decimal item.</li>\n"
+            "      <li>Second nested decimal item.</li>\n"
+            "    </ol>\n"
+            "  </li>\n"
             "</ol>\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_native_nested_decimal_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>
+              Parent item
+              <ol>
+                <li>Nested decimal item.</li>
+                <li>Second nested decimal item.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "1. Parent item\n"
+            "   1. Nested decimal item.\n"
+            "   2. Second nested decimal item.\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_html_list_inside_native_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ul>
+            <li>
+              Parent item
+              <ol type="a">
+                <li>Nested alpha item.</li>
+              </ol>
+            </li>
+          </ul>
+        </div>
+        """
+
+        self.assertEqual(
+            "- Parent item\n"
+            '  <ol type="a">\n'
+            "    <li>Nested alpha item.</li>\n"
+            "  </ol>\n",
             legal_code_html_to_markdown(html),
         )

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -29,7 +29,7 @@ class MarkdownUtilsTest(SimpleTestCase):
         </main>
         """
         expected = (
-            "# Attribution 4.0 International\n\n"
+            "## Attribution 4.0 International\n\n"
             "<u>Adapted Material</u> means material described in "
             "[Section 1](#s1).\n\n"
             '<ol type="a">\n'
@@ -56,7 +56,7 @@ class MarkdownUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "# Title\n\n# Section\n\n## Subsection\n",
+            "# Title\n\n## Section\n\n### Subsection\n",
             legal_code_html_to_markdown(html),
         )
 
@@ -113,7 +113,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertGreater(len(lines), 1)
         self.assertEqual(text, " ".join(lines))
-        self.assertTrue(all(len(line) <= 80 for line in lines))
+        self.assertTrue(all(len(line) <= 70 for line in lines))
 
     def test_legal_code_html_to_markdown_wraps_direct_text_nodes(self):
         text = (
@@ -130,9 +130,9 @@ class MarkdownUtilsTest(SimpleTestCase):
         markdown = legal_code_html_to_markdown(html)
         lines = markdown.splitlines()
 
-        self.assertEqual("# Notice", lines[0])
+        self.assertEqual("## Notice", lines[0])
         self.assertEqual(text, " ".join(lines[2:]))
-        self.assertTrue(all(len(line) <= 80 for line in lines))
+        self.assertTrue(all(len(line) <= 70 for line in lines))
 
     def test_legal_code_html_to_markdown_wraps_markdown_emphasis(self):
         html = """
@@ -149,7 +149,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertIn("**strong emphasis**", markdown)
         self.assertIn("*emphasis text*", markdown)
-        self.assertTrue(all(len(line) <= 80 for line in markdown.splitlines()))
+        self.assertTrue(all(len(line) <= 70 for line in markdown.splitlines()))
 
     def test_legal_code_html_to_markdown_wraps_html_list_items(self):
         text = (
@@ -173,7 +173,7 @@ class MarkdownUtilsTest(SimpleTestCase):
         self.assertEqual("</ol>", lines[-1])
         self.assertNotIn("", lines)
         self.assertEqual(text, " ".join(lines[2:-2]))
-        self.assertTrue(all(len(line) <= 80 for line in lines))
+        self.assertTrue(all(len(line) <= 70 for line in lines))
 
     def test_legal_code_html_to_markdown_wraps_html_block_tags(self):
         text = (
@@ -193,7 +193,7 @@ class MarkdownUtilsTest(SimpleTestCase):
 
         self.assertIn("<p>", lines)
         self.assertIn("</p>", lines)
-        self.assertTrue(all(len(line) <= 80 for line in lines))
+        self.assertTrue(all(len(line) <= 70 for line in lines))
 
     def test_legal_code_html_to_markdown_preserves_long_tokens(self):
         token = f"https://creativecommons.org/{'licensepath' * 9}"
@@ -206,7 +206,27 @@ class MarkdownUtilsTest(SimpleTestCase):
         markdown = legal_code_html_to_markdown(html)
 
         self.assertEqual(f"{token}\n", markdown)
-        self.assertGreater(len(markdown.splitlines()[0]), 80)
+        self.assertGreater(len(markdown.splitlines()[0]), 70)
+
+    def test_legal_code_html_to_markdown_uses_document_root(self):
+        html = """
+        <div id="legal-code-document">
+          <h1>Document Title</h1>
+          <div id="legal-code-body">
+            <h2>Body Title</h2>
+            <p>Legal code body.</p>
+          </div>
+          <p>After legal code.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "# Document Title\n\n"
+            "## Body Title\n\n"
+            "Legal code body.\n\n"
+            "After legal code.\n",
+            legal_code_html_to_markdown(html),
+        )
 
     def test_legal_code_html_to_markdown_nested_decimal_list(self):
         html = """

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -29,7 +29,7 @@ class MarkdownUtilsTest(SimpleTestCase):
         </main>
         """
         expected = (
-            "## Attribution 4.0 International\n\n"
+            "# Attribution 4.0 International\n\n"
             "<u>Adapted Material</u> means material described in "
             "[Section 1](#s1).\n\n"
             "(a) First item\n"
@@ -42,6 +42,20 @@ class MarkdownUtilsTest(SimpleTestCase):
         )
 
         self.assertEqual(expected, legal_code_html_to_markdown(html))
+
+    def test_legal_code_html_to_markdown_heading_levels(self):
+        html = """
+        <div id="legal-code-body">
+          <h1>Title</h1>
+          <h2>Section</h2>
+          <h3>Subsection</h3>
+        </div>
+        """
+
+        self.assertEqual(
+            "# Title\n\n# Section\n\n## Subsection\n",
+            legal_code_html_to_markdown(html),
+        )
 
     def test_legal_code_html_to_markdown_uppercase_list_and_strong(self):
         html = """

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -60,18 +60,21 @@ class MarkdownUtilsTest(SimpleTestCase):
             legal_code_html_to_markdown(html),
         )
 
-    def test_legal_code_html_to_markdown_uppercase_list_and_strong(self):
+    def test_legal_code_html_to_markdown_uppercase_list_and_emphasis(self):
         html = """
         <div id="legal-code-body">
           <ol type="A">
-            <li><strong>Notice</strong> must be retained.</li>
+            <li>
+              <strong>Notice</strong> and <em>care</em> must be retained.
+            </li>
           </ol>
         </div>
         """
 
         self.assertEqual(
             '<ol type="A">\n'
-            "<li><strong>Notice</strong> must be retained.</li>\n"
+            "<li><strong>Notice</strong> and <em>care</em> must be "
+            "retained.</li>\n"
             "</ol>\n",
             legal_code_html_to_markdown(html),
         )
@@ -93,6 +96,117 @@ class MarkdownUtilsTest(SimpleTestCase):
             "</ol>\n",
             legal_code_html_to_markdown(html),
         )
+
+    def test_legal_code_html_to_markdown_wraps_paragraphs(self):
+        text = (
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda "
+            "mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega."
+        )
+        html = f"""
+        <div id="legal-code-body">
+          <p>{text}</p>
+        </div>
+        """
+
+        markdown = legal_code_html_to_markdown(html)
+        lines = markdown.splitlines()
+
+        self.assertGreater(len(lines), 1)
+        self.assertEqual(text, " ".join(lines))
+        self.assertTrue(all(len(line) <= 80 for line in lines))
+
+    def test_legal_code_html_to_markdown_wraps_direct_text_nodes(self):
+        text = (
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda "
+            "mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega."
+        )
+        html = f"""
+        <div id="legal-code-body">
+          <h2>Notice</h2>
+          {text}
+        </div>
+        """
+
+        markdown = legal_code_html_to_markdown(html)
+        lines = markdown.splitlines()
+
+        self.assertEqual("# Notice", lines[0])
+        self.assertEqual(text, " ".join(lines[2:]))
+        self.assertTrue(all(len(line) <= 80 for line in lines))
+
+    def test_legal_code_html_to_markdown_wraps_markdown_emphasis(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            Alpha <strong>strong emphasis</strong> and <em>emphasis
+            text</em> continue through enough words to require wrapping in
+            generated Markdown output.
+          </p>
+        </div>
+        """
+
+        markdown = legal_code_html_to_markdown(html)
+
+        self.assertIn("**strong emphasis**", markdown)
+        self.assertIn("*emphasis text*", markdown)
+        self.assertTrue(all(len(line) <= 80 for line in markdown.splitlines()))
+
+    def test_legal_code_html_to_markdown_wraps_html_list_items(self):
+        text = (
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda "
+            "mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega."
+        )
+        html = f"""
+        <div id="legal-code-body">
+          <ol type="a">
+            <li>{text}</li>
+          </ol>
+        </div>
+        """
+
+        markdown = legal_code_html_to_markdown(html)
+        lines = markdown.splitlines()
+
+        self.assertEqual('<ol type="a">', lines[0])
+        self.assertEqual("<li>", lines[1])
+        self.assertEqual("</li>", lines[-2])
+        self.assertEqual("</ol>", lines[-1])
+        self.assertNotIn("", lines)
+        self.assertEqual(text, " ".join(lines[2:-2]))
+        self.assertTrue(all(len(line) <= 80 for line in lines))
+
+    def test_legal_code_html_to_markdown_wraps_html_block_tags(self):
+        text = (
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda "
+            "mu nu xi omicron pi rho sigma tau."
+        )
+        html = f"""
+        <div id="legal-code-body">
+          <ol>
+            <li><p>{text}</p></li>
+          </ol>
+        </div>
+        """
+
+        markdown = legal_code_html_to_markdown(html)
+        lines = markdown.splitlines()
+
+        self.assertIn("<p>", lines)
+        self.assertIn("</p>", lines)
+        self.assertTrue(all(len(line) <= 80 for line in lines))
+
+    def test_legal_code_html_to_markdown_preserves_long_tokens(self):
+        token = f"https://creativecommons.org/{'licensepath' * 9}"
+        html = f"""
+        <div id="legal-code-body">
+          <p>{token}</p>
+        </div>
+        """
+
+        markdown = legal_code_html_to_markdown(html)
+
+        self.assertEqual(f"{token}\n", markdown)
+        self.assertGreater(len(markdown.splitlines()[0]), 80)
 
     def test_legal_code_html_to_markdown_nested_decimal_list(self):
         html = """

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -100,7 +100,9 @@ class MarkdownUtilsTest(SimpleTestCase):
         <div id="legal-code-body">
           <ol>
             <li>
-              <div><strong>Term</strong> means something.</div>
+              <div class="padding-left-normal">
+                <strong>Term</strong> means something.
+              </div>
             </li>
           </ol>
         </div>
@@ -247,7 +249,9 @@ class MarkdownUtilsTest(SimpleTestCase):
         <div id="legal-code-body">
           <ol type="a">
             <li>
-              <div><strong>Term</strong> means something.</div>
+              <div class="padding-left-normal">
+                <strong>Term</strong> means something.
+              </div>
             </li>
           </ol>
         </div>
@@ -265,7 +269,7 @@ class MarkdownUtilsTest(SimpleTestCase):
         <div id="legal-code-body">
           <ol type="a">
             <li>
-              <div>
+              <div class="padding-left-normal">
                 <p>Introductory paragraph.</p>
                 <ol type="i">
                   <li>Nested item.</li>

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -32,13 +32,16 @@ class MarkdownUtilsTest(SimpleTestCase):
             "# Attribution 4.0 International\n\n"
             "<u>Adapted Material</u> means material described in "
             "[Section 1](#s1).\n\n"
-            "(a) First item\n"
-            "\n"
-            "(b) Second item\n"
-            "\n"
-            "&nbsp;&nbsp;&nbsp;&nbsp;(i) Nested item\n"
-            "\n"
-            "&nbsp;&nbsp;&nbsp;&nbsp;(ii) Second nested item\n"
+            '<ol type="a">\n'
+            "<li>First item</li>\n"
+            "<li>\n"
+            "Second item\n"
+            '<ol type="i">\n'
+            "<li>Nested item</li>\n"
+            "<li>Second nested item</li>\n"
+            "</ol>\n"
+            "</li>\n"
+            "</ol>\n"
         )
 
         self.assertEqual(expected, legal_code_html_to_markdown(html))
@@ -67,7 +70,9 @@ class MarkdownUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "(A) **Notice** must be retained.\n",
+            '<ol type="A">\n'
+            "<li><strong>Notice</strong> must be retained.</li>\n"
+            "</ol>\n",
             legal_code_html_to_markdown(html),
         )
 
@@ -82,7 +87,10 @@ class MarkdownUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "1. First decimal item.\n2. Second decimal item.\n",
+            "<ol>\n"
+            "<li>First decimal item.</li>\n"
+            "<li>Second decimal item.</li>\n"
+            "</ol>\n",
             legal_code_html_to_markdown(html),
         )
 
@@ -102,9 +110,14 @@ class MarkdownUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "(a) Parent item\n\n"
-            "&nbsp;&nbsp;&nbsp;&nbsp;1. Nested decimal item.\n"
-            "\n"
-            "&nbsp;&nbsp;&nbsp;&nbsp;2. Second nested decimal item.\n",
+            '<ol type="a">\n'
+            "<li>\n"
+            "Parent item\n"
+            "<ol>\n"
+            "<li>Nested decimal item.</li>\n"
+            "<li>Second nested decimal item.</li>\n"
+            "</ol>\n"
+            "</li>\n"
+            "</ol>\n",
             legal_code_html_to_markdown(html),
         )

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -92,6 +92,21 @@ class MarkdownUtilsTest(SimpleTestCase):
             legal_code_html_to_markdown(html),
         )
 
+    def test_legal_code_html_to_markdown_escapes_link_syntax(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            <a href="/policies/some path(1)">Policy [draft]</a>
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "[Policy \\[draft\\]]"
+            "(<https://creativecommons.org/policies/some path(1)>)\n",
+            legal_code_html_to_markdown(html),
+        )
+
     def test_legal_code_html_to_markdown_uppercase_list_and_emphasis(self):
         html = """
         <div id="legal-code-body">

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -60,6 +60,38 @@ class MarkdownUtilsTest(SimpleTestCase):
             legal_code_html_to_markdown(html),
         )
 
+    def test_legal_code_html_to_markdown_normalizes_base_less_links(self):
+        html = """
+        <div id="legal-code-body">
+          <p><a href="/policies/">policies</a></p>
+          <p>
+            <a href="//creativecommons.org/compatiblelicenses">
+            compatible licenses</a>
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "[policies](https://creativecommons.org/policies/)\n\n"
+            "[compatible licenses]"
+            "(https://creativecommons.org/compatiblelicenses)\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_preserves_absolute_link_parts(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            <a href="https://example.test/path/?x=1#part">details</a>
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "[details](https://example.test/path/?x=1#part)\n",
+            legal_code_html_to_markdown(html),
+        )
+
     def test_legal_code_html_to_markdown_uppercase_list_and_emphasis(self):
         html = """
         <div id="legal-code-body">
@@ -198,6 +230,23 @@ class MarkdownUtilsTest(SimpleTestCase):
         self.assertIn("**strong emphasis**", markdown)
         self.assertIn("*emphasis text*", markdown)
         self.assertTrue(all(len(line) <= 71 for line in markdown.splitlines()))
+
+    def test_legal_code_html_to_markdown_normalizes_links_in_html_lists(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li><a href="/policies/">policies</a></li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            '<ol type="a">\n'
+            '  <li><a href="https://creativecommons.org/policies/">'
+            "policies</a></li>\n"
+            "</ol>\n",
+            legal_code_html_to_markdown(html),
+        )
 
     def test_legal_code_html_to_markdown_wraps_html_list_items(self):
         text = (

--- a/legal_tools/tests/test_markdown_utils.py
+++ b/legal_tools/tests/test_markdown_utils.py
@@ -1,0 +1,96 @@
+# Third-party
+from django.test import SimpleTestCase
+
+# First-party/Local
+from legal_tools.markdown_utils import legal_code_html_to_markdown
+
+
+class MarkdownUtilsTest(SimpleTestCase):
+    def test_legal_code_html_to_markdown(self):
+        html = """
+        <main>
+          <div id="legal-code-body">
+            <h2>Attribution 4.0 International</h2>
+            <p>
+              <span style="text-decoration: underline;">Adapted Material</span>
+              means material described in <a href="#s1">Section 1</a>.
+            </p>
+            <ol type="a">
+              <li>First item</li>
+              <li>
+                Second item
+                <ol type="i">
+                  <li>Nested item</li>
+                  <li>Second nested item</li>
+                </ol>
+              </li>
+            </ol>
+          </div>
+        </main>
+        """
+        expected = (
+            "## Attribution 4.0 International\n\n"
+            "<u>Adapted Material</u> means material described in "
+            "[Section 1](#s1).\n\n"
+            "(a) First item\n"
+            "\n"
+            "(b) Second item\n"
+            "\n"
+            "&nbsp;&nbsp;&nbsp;&nbsp;(i) Nested item\n"
+            "\n"
+            "&nbsp;&nbsp;&nbsp;&nbsp;(ii) Second nested item\n"
+        )
+
+        self.assertEqual(expected, legal_code_html_to_markdown(html))
+
+    def test_legal_code_html_to_markdown_uppercase_list_and_strong(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="A">
+            <li><strong>Notice</strong> must be retained.</li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "(A) **Notice** must be retained.\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_decimal_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>First decimal item.</li>
+            <li>Second decimal item.</li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "1. First decimal item.\n2. Second decimal item.\n",
+            legal_code_html_to_markdown(html),
+        )
+
+    def test_legal_code_html_to_markdown_nested_decimal_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li>
+              Parent item
+              <ol>
+                <li>Nested decimal item.</li>
+                <li>Second nested decimal item.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "(a) Parent item\n\n"
+            "&nbsp;&nbsp;&nbsp;&nbsp;1. Nested decimal item.\n"
+            "\n"
+            "&nbsp;&nbsp;&nbsp;&nbsp;2. Second nested decimal item.\n",
+            legal_code_html_to_markdown(html),
+        )

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -180,33 +180,6 @@ class LegalCodeModelTest(TestCase):
                     ).translation_filename(),
                 )
 
-    # NOTE: plaintext functionality disabled
-    # def test_plain_text_url(self):
-    #     lc0 = LegalCodeFactory(
-    #         tool__unit="by",
-    #         tool__version="4.0",
-    #         tool__jurisdiction_code="",
-    #         language_code="en",
-    #     )
-    #     lc1 = LegalCodeFactory(
-    #         tool__unit="by",
-    #         tool__version="4.0",
-    #         tool__jurisdiction_code="",
-    #         language_code="fr",
-    #     )
-    #     lc2 = LegalCodeFactory(
-    #         tool__unit="by",
-    #         tool__version="4.0",
-    #         tool__jurisdiction_code="",
-    #         language_code="ar",
-    #     )
-    #     self.assertEqual(
-    #         lc0.plain_text_url,
-    #         f"{lc0.legal_code_url.replace('legalcode.en', 'legalcode.txt')}",
-    #     )
-    #     self.assertEqual(lc1.plain_text_url, "")
-    #     self.assertEqual(lc2.plain_text_url, "")
-
     def test_get_pofile(self):
         legal_code = LegalCodeFactory()
         test_pofile = polib.POFile()

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -525,6 +525,88 @@ class LegalCodeModelTest(TestCase):
 
         self.assertIsNone(returned_list)
 
+    # get_plaintext_publish_file legal code ##################################
+
+    def test_get_plaintext_publish_file_by4_legal_code_en(self):
+        legal_code = LegalCodeFactory(
+            tool__category="licenses",
+            tool__unit="by",
+            tool__version="4.0",
+            language_code="en",
+        )
+
+        returned_path = legal_code.get_plaintext_publish_file()
+
+        self.assertEqual("licenses/by/4.0/legalcode.en.txt", returned_path)
+
+    def test_get_plaintext_publish_file_by4_legal_code_zh_hant(self):
+        legal_code = LegalCodeFactory(
+            tool__category="licenses",
+            tool__unit="by",
+            tool__version="4.0",
+            language_code="zh-hant",
+        )
+
+        returned_path = legal_code.get_plaintext_publish_file()
+
+        self.assertEqual(
+            "licenses/by/4.0/legalcode.zh-hant.txt",
+            returned_path,
+        )
+
+    def test_get_plaintext_publish_file_by3_ported_legal_code_de(self):
+        legal_code = LegalCodeFactory(
+            tool__category="licenses",
+            tool__unit="by",
+            tool__version="3.0",
+            tool__jurisdiction_code="de",
+            language_code="de",
+        )
+
+        returned_path = legal_code.get_plaintext_publish_file()
+
+        self.assertEqual("licenses/by/3.0/de/legalcode.de.txt", returned_path)
+
+    def test_get_plaintext_publish_file_by2_legal_code_en(self):
+        legal_code = LegalCodeFactory(
+            tool__category="licenses",
+            tool__unit="by",
+            tool__version="2.0",
+            language_code="en",
+        )
+
+        returned_path = legal_code.get_plaintext_publish_file()
+
+        self.assertEqual("licenses/by/2.0/legalcode.en.txt", returned_path)
+
+    def test_get_plaintext_publish_file_zero_legal_code_en(self):
+        legal_code = LegalCodeFactory(
+            tool__category="publicdomain",
+            tool__unit="zero",
+            tool__version="1.0",
+            language_code="en",
+        )
+
+        returned_path = legal_code.get_plaintext_publish_file()
+
+        self.assertEqual(
+            "publicdomain/zero/1.0/legalcode.en.txt",
+            returned_path,
+        )
+
+    def test_get_plaintext_publish_file_mark_legal_code_en(self):
+        legal_code = LegalCodeFactory(
+            tool__category="publicdomain",
+            tool__deed_only=True,
+            tool__unit="mark",
+            tool__version="1.0",
+            language_code="en",
+        )
+
+        returned_path = legal_code.get_plaintext_publish_file()
+
+        self.assertIsNone(returned_path)
+
     # get_redirect_pairs #####################################################
 
     def test_get_redirect_pairs(self):

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -437,6 +437,38 @@ class LegalCodeModelTest(TestCase):
             returned_list,
         )
 
+    # get_markdown_publish_files legal code ##################################
+
+    def test_get_markdown_publish_files_by_nc_nd4_legal_code_en(self):
+        legal_code = LegalCodeFactory(
+            tool__category="licenses",
+            tool__unit="by-nc-nd",
+            tool__version="4.0",
+            language_code="en",
+        )
+
+        returned_list = legal_code.get_markdown_publish_files()
+
+        self.assertEqual(
+            "licenses/by-nc-nd/4.0/legalcode.en.md",
+            returned_list,
+        )
+
+    def test_get_markdown_publish_files_by_nc_nd4_legal_code_zh_hant(self):
+        legal_code = LegalCodeFactory(
+            tool__category="licenses",
+            tool__unit="by-nc-nd",
+            tool__version="4.0",
+            language_code="zh-hant",
+        )
+
+        returned_list = legal_code.get_markdown_publish_files()
+
+        self.assertEqual(
+            "licenses/by-nc-nd/4.0/legalcode.zh-hant.md",
+            returned_list,
+        )
+
     # get_publish_files Mark 1.0 legal code ##################################
     # Mark 1.0 is a universal (unported) deed-only declaration
 
@@ -479,6 +511,19 @@ class LegalCodeModelTest(TestCase):
             ],
             returned_list,
         )
+
+    def test_get_markdown_publish_files_mark_legal_code_en(self):
+        legal_code = LegalCodeFactory(
+            tool__category="publicdomain",
+            tool__deed_only=True,
+            tool__unit="mark",
+            tool__version="1.0",
+            language_code="en",
+        )
+
+        returned_list = legal_code.get_markdown_publish_files()
+
+        self.assertIsNone(returned_list)
 
     # get_redirect_pairs #####################################################
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -4,6 +4,7 @@ from django.test import SimpleTestCase
 # First-party/Local
 from legal_tools.plaintext_utils import (
     PLAIN_TEXT_SEPARATOR,
+    PlainTextRenderError,
     legal_code_html_to_plain_text,
 )
 
@@ -145,6 +146,22 @@ class PlainTextUtilsTest(SimpleTestCase):
         self.assertEqual(
             f"{lead}3(a)(1)(A)\n"
             "(i). applies.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_wraps_section_reference_ranges(
+        self,
+    ):
+        lead = f"{'x' * 55} Section "
+        html = f"""
+        <div id="legal-code-body">
+          <p>{lead}2(b)(1)-(2) applies.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            f"{lead}2(b)\n"
+            "(1)-(2) applies.\n",
             legal_code_html_to_plain_text(html),
         )
 
@@ -521,13 +538,11 @@ class PlainTextUtilsTest(SimpleTestCase):
         </div>
         """
 
-        self.assertEqual(
-            "viii. Alpha beta gamma delta epsilon zeta eta theta iota kappa "
-            "lambda\n"
-            "      mu nu xi omicron pi rho sigma tau upsilon phi chi psi "
-            "omega.\n",
-            legal_code_html_to_plain_text(html),
-        )
+        with self.assertRaisesRegex(
+            PlainTextRenderError,
+            "List marker exceeds 3 characters: viii",
+        ):
+            legal_code_html_to_plain_text(html)
 
     def test_legal_code_html_to_plain_text_links(self):
         html = """

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -312,6 +312,28 @@ class PlainTextUtilsTest(SimpleTestCase):
             legal_code_html_to_plain_text(html),
         )
 
+    def test_legal_code_html_to_plain_text_list_width_is_document_wide(self):
+        html = """
+        <div id="legal-code-body">
+          <ul>
+            <li>Bullet</li>
+          </ul>
+          <ol>
+            <li>Decimal</li>
+          </ol>
+          <ol type="i" start="8">
+            <li>Roman</li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "    - Bullet\n\n"
+            "   1. Decimal\n\n"
+            "viii. Roman\n",
+            legal_code_html_to_plain_text(html),
+        )
+
     def test_legal_code_html_to_plain_text_nested_list_indentation(self):
         html = """
         <div id="legal-code-body">
@@ -329,6 +351,28 @@ class PlainTextUtilsTest(SimpleTestCase):
         self.assertEqual(
             "  1. Parent item\n\n"
             "       i. Nested item\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_nested_list_dynamic_indentation(
+        self,
+    ):
+        html = """
+        <div id="legal-code-body">
+          <ol type="i" start="8">
+            <li>
+              Parent item
+              <ol>
+                <li>Nested item</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "viii. Parent item\n\n"
+            "         1. Nested item\n",
             legal_code_html_to_plain_text(html),
         )
 
@@ -566,7 +610,9 @@ class PlainTextUtilsTest(SimpleTestCase):
             legal_code_html_to_plain_text(html),
         )
 
-    def test_legal_code_html_to_plain_text_long_marker(self):
+    def test_legal_code_html_to_plain_text_long_marker_expands_list_width(
+        self,
+    ):
         html = """
         <div id="legal-code-body">
           <ol type="i" start="8">
@@ -578,9 +624,26 @@ class PlainTextUtilsTest(SimpleTestCase):
         </div>
         """
 
+        self.assertEqual(
+            "viii. Alpha beta gamma delta epsilon zeta eta theta iota "
+            "kappa lambda\n"
+            "      mu nu xi omicron pi rho sigma tau upsilon phi chi "
+            "psi omega.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_invalid_roman_marker(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="i" start="0">
+            <li>Invalid marker</li>
+          </ol>
+        </div>
+        """
+
         with self.assertRaisesRegex(
             PlainTextRenderError,
-            "List marker exceeds 3 characters: viii",
+            "Roman list marker requires positive number: 0",
         ):
             legal_code_html_to_plain_text(html)
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -21,7 +21,7 @@ class PlainTextUtilsTest(SimpleTestCase):
             <h2>Using</h2>
             <p>More preface text.</p>
             <hr class="divider">
-            <h3>Internal</h3>
+            <h3 class="level is-vcentered b-header">Internal</h3>
             <p>Internal notice text.</p>
           </div>
           <div id="legal-code-body">
@@ -154,13 +154,13 @@ class PlainTextUtilsTest(SimpleTestCase):
           <h2>Using</h2>
           <p>Intro text.</p>
           <hr class="divider">
-          <h3>Licensors</h3>
+          <h3 class="level is-vcentered b-header">Licensors</h3>
           <p>
             Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
             mu nu.
           </p>
           <hr class="divider">
-          <h3>Public</h3>
+          <h3 class="level is-vcentered b-header">Public</h3>
           <p>Gamma delta.</p>
         </div>
         """
@@ -196,6 +196,66 @@ class PlainTextUtilsTest(SimpleTestCase):
         self.assertEqual(
             "Using\n\n"
             "Fallback text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_plain_notice_h3(self):
+        html = """
+        <div id="about-cc-and-license" class="notice-top">
+          <h2>Using</h2>
+          <hr class="divider">
+          <h3>Plain Heading</h3>
+          <p>Fallback text.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Using\n\n"
+            "Plain Heading\n\n"
+            "Fallback text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_notice_aside_without_divider(self):
+        html = """
+        <div id="about-cc-and-license" class="notice-top">
+          <h2>Using</h2>
+          <p>Intro text.</p>
+          <h3 class="level is-vcentered b-header">Licensors</h3>
+          <p>Aside text.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Using\n\n"
+            "Intro text.\n\n"
+            "     Licensors: Aside text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_notice_aside_stops(self):
+        html = """
+        <div id="about-cc-and-license" class="notice-top">
+          <h2>Using</h2>
+          <h3 class="level is-vcentered b-header">Licensors</h3>
+          <p>Aside text.</p>
+          <h2>Next</h2>
+          <p>Normal text.</p>
+          <hr class="divider">
+          <h3 class="level is-vcentered b-header">Public</h3>
+          <p>Public text.</p>
+          <hr class="divider">
+          <p>After divider.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Using\n\n"
+            "     Licensors: Aside text.\n\n"
+            "Next\n\n"
+            "Normal text.\n\n"
+            "     Public: Public text.\n\n"
+            "After divider.\n",
             legal_code_html_to_plain_text(html),
         )
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -119,6 +119,35 @@ class PlainTextUtilsTest(SimpleTestCase):
         self.assertEqual(text, " ".join(lines))
         self.assertTrue(all(len(line) <= 71 for line in lines))
 
+    def test_legal_code_html_to_plain_text_wraps_section_references(self):
+        text = f"{'Alpha ' * 9}Beta Section 2(b)(1) applies."
+        html = f"""
+        <div id="legal-code-body">
+          <p>{text}</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Alpha Alpha Alpha Alpha Alpha Alpha Alpha Alpha Alpha "
+            "Beta Section 2(b)\n"
+            "(1) applies.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_wraps_deep_section_references(self):
+        lead = f"{'x' * 52} Section "
+        html = f"""
+        <div id="legal-code-body">
+          <p>{lead}3(a)(1)(A)(i). applies.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            f"{lead}3(a)(1)(A)\n"
+            "(i). applies.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
     def test_legal_code_html_to_plain_text_notice_asides(self):
         html = """
         <div id="about-cc-and-license" class="notice-top">
@@ -318,6 +347,24 @@ class PlainTextUtilsTest(SimpleTestCase):
 
         self.assertTrue(lines[0].startswith("   - "))
         self.assertTrue(all(line.startswith("     ") for line in lines[1:]))
+
+    def test_legal_code_html_to_plain_text_wraps_section_references_in_lists(
+        self,
+    ):
+        lead = f"{'x' * 56} Section "
+        html = f"""
+        <div id="legal-code-body">
+          <ol>
+            <li>{lead}2(b)(1) applies.</li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            f"  1. {lead}2\n"
+            "     (b)(1) applies.\n",
+            legal_code_html_to_plain_text(html),
+        )
 
     def test_legal_code_html_to_plain_text_replaces_en_dash(self):
         html = """

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -269,6 +269,18 @@ class PlainTextUtilsTest(SimpleTestCase):
             legal_code_html_to_plain_text(html),
         )
 
+    def test_legal_code_html_to_plain_text_replaces_curly_quotes(self):
+        html = """
+        <div id="legal-code-body">
+          <p>The licensor’s “request” is reasonable.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            'The licensor\'s "request" is reasonable.\n',
+            legal_code_html_to_plain_text(html),
+        )
+
     def test_legal_code_html_to_plain_text_does_not_wrap_after_en_dash(self):
         html = """
         <div id="legal-code-body">
@@ -297,6 +309,34 @@ class PlainTextUtilsTest(SimpleTestCase):
 
         self.assertIn(
             "CC-\nlicensed",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_bold_style_uppercase(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li style="font-weight: bold;">
+              <strong>Unless otherwise undertaken.</strong>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  a. UNLESS OTHERWISE UNDERTAKEN.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_strong_not_uppercase(self):
+        html = """
+        <div id="legal-code-body">
+          <p><strong>Your</strong> has a corresponding meaning.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Your has a corresponding meaning.\n",
             legal_code_html_to_plain_text(html),
         )
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -221,8 +221,30 @@ class PlainTextUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "  1. Parent item\n"
+            "  1. Parent item\n\n"
             "       i. Nested item\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_list_item_block_spacing(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>
+              Intro
+              <ol>
+                <li>Nested item</li>
+              </ol>
+              Tail
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  1. Intro\n\n"
+            "       1. Nested item\n\n"
+            "     Tail\n",
             legal_code_html_to_plain_text(html),
         )
 
@@ -230,13 +252,15 @@ class PlainTextUtilsTest(SimpleTestCase):
         html = """
         <div id="legal-code-body">
           <ul>
-            <li>Bullet item</li>
+            <li>First bullet item</li>
+            <li>Second bullet item</li>
           </ul>
         </div>
         """
 
         self.assertEqual(
-            "   - Bullet item\n",
+            "   - First bullet item\n\n"
+            "   - Second bullet item\n",
             legal_code_html_to_plain_text(html),
         )
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -71,6 +71,57 @@ class PlainTextUtilsTest(SimpleTestCase):
         self.assertEqual(text, " ".join(lines))
         self.assertTrue(all(len(line) <= 71 for line in lines))
 
+    def test_legal_code_html_to_plain_text_notice_asides(self):
+        html = """
+        <div id="about-cc-and-license" class="notice-top">
+          <h2>Using</h2>
+          <p>Intro text.</p>
+          <hr class="divider">
+          <h3>Licensors</h3>
+          <p>
+            Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
+            mu nu.
+          </p>
+          <hr class="divider">
+          <h3>Public</h3>
+          <p>Gamma delta.</p>
+        </div>
+        """
+
+        plain_text = legal_code_html_to_plain_text(html)
+
+        self.assertEqual(
+            "Using\n\n"
+            "Intro text.\n\n"
+            "     Licensors: Alpha beta gamma delta epsilon zeta eta theta iota\n"
+            "     kappa lambda mu nu.\n\n"
+            "     Public: Gamma delta.\n",
+            plain_text,
+        )
+        aside_lines = [
+            line
+            for line in plain_text.splitlines()
+            if line.startswith("     ")
+        ]
+        self.assertTrue(aside_lines)
+        self.assertTrue(all(len(line) <= 66 for line in aside_lines))
+        self.assertTrue(all(line == line.rstrip() for line in aside_lines))
+
+    def test_legal_code_html_to_plain_text_notice_divider_fallback(self):
+        html = """
+        <div id="about-cc-and-license" class="notice-top">
+          <h2>Using</h2>
+          <hr class="divider">
+          <p>Fallback text.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Using\n\n"
+            "Fallback text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
     def test_legal_code_html_to_plain_text_ordered_list_markers(self):
         html = """
         <div id="legal-code-body">
@@ -137,7 +188,67 @@ class PlainTextUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "  -. Bullet item\n",
+            "   - Bullet item\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_unordered_list_wrap(self):
+        html = """
+        <div id="legal-code-body">
+          <ul>
+            <li>
+              Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
+              mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.
+            </li>
+          </ul>
+        </div>
+        """
+
+        lines = legal_code_html_to_plain_text(html).splitlines()
+
+        self.assertTrue(lines[0].startswith("   - "))
+        self.assertTrue(all(line.startswith("     ") for line in lines[1:]))
+
+    def test_legal_code_html_to_plain_text_replaces_en_dash(self):
+        html = """
+        <div id="legal-code-body">
+          <h3>Section 1 – Definitions.</h3>
+        </div>
+        """
+
+        self.assertEqual(
+            "Section 1 -- Definitions.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_does_not_wrap_after_en_dash(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            reason–for example.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"
+            "reason--for example.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_wraps_after_hyphens(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            Alpha Alpha Alpha Alpha Alpha Alpha Alpha Alpha Alpha Alpha x
+            CC-licensed material.
+          </p>
+        </div>
+        """
+
+        self.assertIn(
+            "CC-\nlicensed",
             legal_code_html_to_plain_text(html),
         )
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -69,7 +69,7 @@ class PlainTextUtilsTest(SimpleTestCase):
 
         self.assertGreater(len(lines), 1)
         self.assertEqual(text, " ".join(lines))
-        self.assertTrue(all(len(line) <= 70 for line in lines))
+        self.assertTrue(all(len(line) <= 71 for line in lines))
 
     def test_legal_code_html_to_plain_text_ordered_list_markers(self):
         html = """

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -1,0 +1,191 @@
+# Third-party
+from django.test import SimpleTestCase
+
+# First-party/Local
+from legal_tools.plaintext_utils import (
+    PLAIN_TEXT_SEPARATOR,
+    legal_code_html_to_plain_text,
+)
+
+
+class PlainTextUtilsTest(SimpleTestCase):
+    def test_legal_code_html_to_plain_text_document_regions(self):
+        html = """
+        <div id="legal-code-document">
+          <h1>Document Title</h1>
+          <div class="notice-top">
+            <h2>About</h2>
+            <p>Preface text.</p>
+          </div>
+          <div class="notice-top">
+            <h2>Using</h2>
+            <p>More preface text.</p>
+            <hr class="divider">
+            <h3>Internal</h3>
+            <p>Internal notice text.</p>
+          </div>
+          <div id="legal-code-body">
+            <h2>Body Title</h2>
+            <p>Body text.</p>
+          </div>
+          <div class="notice-bottom">
+            <h2>Footer</h2>
+            <p>Footer text.</p>
+          </div>
+        </div>
+        """
+
+        self.assertEqual(
+            "Document Title\n\n"
+            f"{PLAIN_TEXT_SEPARATOR}\n\n"
+            "About\n\n"
+            "Preface text.\n\n"
+            "Using\n\n"
+            "More preface text.\n\n"
+            "Internal\n\n"
+            "Internal notice text.\n\n"
+            f"{PLAIN_TEXT_SEPARATOR}\n\n"
+            "Body Title\n\n"
+            "Body text.\n\n"
+            f"{PLAIN_TEXT_SEPARATOR}\n\n"
+            "Footer\n\n"
+            "Footer text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_wraps_paragraphs(self):
+        text = (
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda "
+            "mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega."
+        )
+        html = f"""
+        <div id="legal-code-body">
+          <p>{text}</p>
+        </div>
+        """
+
+        plain_text = legal_code_html_to_plain_text(html)
+        lines = plain_text.splitlines()
+
+        self.assertGreater(len(lines), 1)
+        self.assertEqual(text, " ".join(lines))
+        self.assertTrue(all(len(line) <= 70 for line in lines))
+
+    def test_legal_code_html_to_plain_text_ordered_list_markers(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>World</li>
+          </ol>
+          <ol type="a" start="2">
+            <li>Lower alpha</li>
+          </ol>
+          <ol type="A" start="3">
+            <li>Upper alpha</li>
+          </ol>
+          <ol type="i" start="3">
+            <li>Lower roman</li>
+          </ol>
+          <ol type="I" start="2">
+            <li>Upper roman</li>
+          </ol>
+          <ol reversed start="3">
+            <li>Three</li>
+            <li>Two</li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  1. World\n\n"
+            "  b. Lower alpha\n\n"
+            "  C. Upper alpha\n\n"
+            "iii. Lower roman\n\n"
+            " II. Upper roman\n\n"
+            "  3. Three\n\n"
+            "  2. Two\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_nested_list_indentation(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>
+              Parent item
+              <ol type="i">
+                <li>Nested item</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  1. Parent item\n"
+            "       i. Nested item\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_unordered_list(self):
+        html = """
+        <div id="legal-code-body">
+          <ul>
+            <li>Bullet item</li>
+          </ul>
+        </div>
+        """
+
+        self.assertEqual(
+            "  -. Bullet item\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_long_marker(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="i" start="8">
+            <li>
+              Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
+              mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "viii. Alpha beta gamma delta epsilon zeta eta theta iota kappa "
+            "lambda\n"
+            "      mu nu xi omicron pi rho sigma tau upsilon phi chi psi "
+            "omega.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_links(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            See <a href="#s1">Section 1</a> and
+            <a href="https://example.test/">example</a>.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "See Section 1 and example: https://example.test/.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_sentence_link(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            Read <a href="https://example.test/">the full document.</a>
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Read the full document. https://example.test/\n",
+            legal_code_html_to_plain_text(html),
+        )

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -376,6 +376,46 @@ class PlainTextUtilsTest(SimpleTestCase):
             legal_code_html_to_plain_text(html),
         )
 
+    def test_legal_code_html_to_plain_text_unwraps_div_in_list_item(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li>
+              <div class="padding-left-normal">
+                <strong>Adaptation</strong> means something.
+              </div>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  a. Adaptation means something.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_unwraps_div_around_blocks(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a">
+            <li>
+              <div class="padding-left-normal">
+                <p>Introductory paragraph.</p>
+                <ol type="i">
+                  <li>Nested item.</li>
+                </ol>
+              </div>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  a. Introductory paragraph.\n\n"
+            "       i. Nested item.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
     def test_legal_code_html_to_plain_text_list_item_first_paragraph(self):
         html = """
         <div id="legal-code-body">

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -13,11 +13,11 @@ class PlainTextUtilsTest(SimpleTestCase):
         html = """
         <div id="legal-code-document">
           <h1>Document Title</h1>
-          <div class="notice-top">
+          <div id="notice-about-licenses-and-cc" class="notice-top">
             <h2>About</h2>
             <p>Preface text.</p>
           </div>
-          <div class="notice-top">
+          <div id="about-cc-and-license" class="notice-top">
             <h2>Using</h2>
             <p>More preface text.</p>
             <hr class="divider">
@@ -28,7 +28,7 @@ class PlainTextUtilsTest(SimpleTestCase):
             <h2>Body Title</h2>
             <p>Body text.</p>
           </div>
-          <div class="notice-bottom">
+          <div id="notice-about-cc-and-trademark" class="notice-bottom">
             <h2>Footer</h2>
             <p>Footer text.</p>
           </div>
@@ -38,18 +38,66 @@ class PlainTextUtilsTest(SimpleTestCase):
         self.assertEqual(
             "Document Title\n\n"
             f"{PLAIN_TEXT_SEPARATOR}\n\n"
-            "About\n\n"
             "Preface text.\n\n"
             "Using\n\n"
             "More preface text.\n\n"
-            "Internal\n\n"
-            "Internal notice text.\n\n"
+            "     Internal: Internal notice text.\n\n"
             f"{PLAIN_TEXT_SEPARATOR}\n\n"
             "Body Title\n\n"
             "Body text.\n\n"
             f"{PLAIN_TEXT_SEPARATOR}\n\n"
-            "Footer\n\n"
             "Footer text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_legal_section_spacing(self):
+        html = """
+        <div id="legal-code-document">
+          <h1>Document Title</h1>
+          <div id="legal-code-body">
+            <h2 id="legal-code-title">Body Title</h2>
+            <p>Intro text.</p>
+            <h3 id="s1">Section 1 – Definitions.</h3>
+            <p>First section text.</p>
+            <h3 id="s2">Section 2 – Scope.</h3>
+            <p>Second section text.</p>
+          </div>
+          <div id="notice-about-cc-and-trademark" class="notice-bottom">
+            <h2>Footer</h2>
+            <p>Footer text.</p>
+          </div>
+        </div>
+        """
+
+        self.assertEqual(
+            "Document Title\n\n"
+            f"{PLAIN_TEXT_SEPARATOR}\n\n"
+            "Body Title\n\n"
+            "Intro text.\n\n"
+            "Section 1 -- Definitions.\n\n"
+            "First section text.\n\n\n"
+            "Section 2 -- Scope.\n\n"
+            "Second section text.\n\n\n"
+            f"{PLAIN_TEXT_SEPARATOR}\n\n"
+            "Footer text.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_non_section_heading_spacing(self):
+        html = """
+        <div id="legal-code-body">
+          <h3 id="topic">Topic</h3>
+          <p>Topic text.</p>
+          <h3>Another Topic</h3>
+          <p>Another text.</p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Topic\n\n"
+            "Topic text.\n\n"
+            "Another Topic\n\n"
+            "Another text.\n",
             legal_code_html_to_plain_text(html),
         )
 

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -248,6 +248,44 @@ class PlainTextUtilsTest(SimpleTestCase):
             legal_code_html_to_plain_text(html),
         )
 
+    def test_legal_code_html_to_plain_text_list_item_paragraph_spacing(self):
+        html = """
+        <div id="legal-code-body">
+          <ol type="a" start="2">
+            <li>
+              <strong>ShareAlike</strong>.
+              <p>In addition, the following conditions also apply.</p>
+              <ol>
+                <li>Nested condition</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  b. ShareAlike.\n\n"
+            "     In addition, the following conditions also apply.\n\n"
+            "       1. Nested condition\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_list_item_first_paragraph(self):
+        html = """
+        <div id="legal-code-body">
+          <ol>
+            <li>
+              <p>Only paragraph.</p>
+            </li>
+          </ol>
+        </div>
+        """
+
+        self.assertEqual(
+            "  1. Only paragraph.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
     def test_legal_code_html_to_plain_text_unordered_list(self):
         html = """
         <div id="legal-code-body">

--- a/legal_tools/tests/test_plaintext_utils.py
+++ b/legal_tools/tests/test_plaintext_utils.py
@@ -658,7 +658,7 @@ class PlainTextUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "See Section 1 and example: https://example.test/.\n",
+            "See Section 1 and example: example.test.\n",
             legal_code_html_to_plain_text(html),
         )
 
@@ -672,6 +672,79 @@ class PlainTextUtilsTest(SimpleTestCase):
         """
 
         self.assertEqual(
-            "Read the full document. https://example.test/\n",
+            "Read the full document: example.test\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_matching_link_label(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            Creative Commons may be contacted at
+            <a href="//creativecommons.org/">creativecommons.org</a>.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Creative Commons may be contacted at creativecommons.org.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_root_relative_link(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            See <a href="/policies/">creativecommons.org/policies</a>.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "See creativecommons.org/policies.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_link_strips_query_fragment(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            See
+            <a href="https://example.test/path/?x=1#part">details</a>.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "See details: example.test/path.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_root_relative_link_label(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            See <a href="/policies/#license">noted</a>.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "See noted: creativecommons.org/policies.\n",
+            legal_code_html_to_plain_text(html),
+        )
+
+    def test_legal_code_html_to_plain_text_mailto_matching_label(self):
+        html = """
+        <div id="legal-code-body">
+          <p>
+            Email <a href="mailto:info@creativecommons.org">
+            info@creativecommons.org</a>.
+          </p>
+        </div>
+        """
+
+        self.assertEqual(
+            "Email info@creativecommons.org.\n",
             legal_code_html_to_plain_text(html),
         )

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -845,10 +845,99 @@ class ViewLegalCodeTest(TestCase):
             context = rsp.context
             self.assertEqual(lc, context["legal_code"])
             self.assertContains(rsp, f'lang="{language_code}"')
+            self.assertContains(
+                rsp, f'href="legalcode.{language_code}.md"'
+            )
             if language_code == "es":
                 self.assertContains(rsp, 'dir="ltr"')
             elif language_code == "ar":
                 self.assertContains(rsp, 'dir="rtl"')
+
+    def test_view_legal_code_markdown_40_language_specified(self):
+        tool = ToolFactory(
+            category="licenses",
+            base_url="https://creativecommons.org/licenses/by/4.0/",
+            unit="by",
+            version="4.0",
+        )
+        legal_code = LegalCodeFactory(
+            tool=tool,
+            language_code=settings.LANGUAGE_CODE,
+        )
+        url = f"{legal_code.legal_code_url}.md"
+
+        rsp = self.client.get(url)
+        content = rsp.content.decode("utf-8")
+
+        self.assertEqual(f"{rsp.status_code} {url}", f"200 {url}")
+        self.assertEqual(
+            rsp.headers["Content-Type"], "text/markdown; charset=utf-8"
+        )
+        self.assertIn("## Attribution 4.0 International", content)
+        self.assertIn("Section 1", content)
+        self.assertIn("(a) <u>Adapted Material</u>", content)
+        self.assertNotIn("1. (a)", content)
+        self.assertNotIn("<html", content)
+        self.assertNotIn("About the license and Creative Commons", content)
+
+    def test_view_legal_code_markdown_40_default_language(self):
+        tool = ToolFactory(
+            category="licenses",
+            base_url="https://creativecommons.org/licenses/by/4.0/",
+            unit="by",
+            version="4.0",
+        )
+        LegalCodeFactory(
+            tool=tool,
+            language_code=settings.LANGUAGE_CODE,
+        )
+        url = "/licenses/by/4.0/legalcode.md"
+
+        rsp = self.client.get(url)
+        content = rsp.content.decode("utf-8")
+
+        self.assertEqual(f"{rsp.status_code} {url}", f"200 {url}")
+        self.assertIn("## Attribution 4.0 International", content)
+
+    def test_view_legal_code_markdown_legacy_raw_html(self):
+        legal_code = LegalCodeFactory(
+            html="<p><strong>Legacy</strong> body</p>",
+            language_code="de",
+            title="Legacy Title",
+            tool__category="licenses",
+            tool__base_url="https://creativecommons.org"
+            "/licenses/by/3.0/de/",
+            tool__unit="by",
+            tool__version="3.0",
+            tool__jurisdiction_code="de",
+        )
+        url = f"{legal_code.legal_code_url}.md"
+
+        rsp = self.client.get(url)
+        content = rsp.content.decode("utf-8")
+
+        self.assertEqual(f"{rsp.status_code} {url}", f"200 {url}")
+        self.assertEqual(
+            rsp.headers["Content-Type"], "text/markdown; charset=utf-8"
+        )
+        self.assertIn("## Legacy Title", content)
+        self.assertIn("**Legacy** body", content)
+
+    def test_view_legal_code_markdown_deed_only_404(self):
+        legal_code = LegalCodeFactory(
+            language_code="en",
+            tool__category="publicdomain",
+            tool__base_url="https://creativecommons.org"
+            "/publicdomain/mark/1.0/",
+            tool__deed_only=True,
+            tool__unit="mark",
+            tool__version="1.0",
+        )
+        url = f"{legal_code.legal_code_url}.md"
+
+        rsp = self.client.get(url)
+
+        self.assertEqual(f"{rsp.status_code} {url}", f"404 {url}")
 
     @override_settings(
         LANGUAGES_MOSTLY_TRANSLATED=["es", settings.LANGUAGE_CODE],

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -851,6 +851,7 @@ class ViewLegalCodeTest(TestCase):
             self.assertContains(
                 rsp, f'href="legalcode.{language_code}.txt"'
             )
+            self.assertNotContains(rsp, 'href="legalcode.txt"')
             if language_code == "es":
                 self.assertContains(rsp, 'dir="ltr"')
             elif language_code == "ar":
@@ -1007,39 +1008,6 @@ class ViewLegalCodeTest(TestCase):
         self.assertEqual(lc, context["legal_code"])
         self.assertContains(rsp, f'lang="{language_code}"')
         self.assertContains(rsp, 'dir="ltr"')
-
-    # NOTE: plaintext functionality disabled
-    # def test_view_legal_code_plain_text(self):
-    #     tool = ToolFactory(
-    #         base_url="https://creativecommons.org/licenses/by/4.0/",
-    #         version="4.0",
-    #     )
-    #     for language_code in [settings.LANGUAGE_CODE]:
-    #         lc = LegalCodeFactory(
-    #             tool=tool,
-    #             language_code=language_code,
-    #         )
-    #         url = lc.plain_text_url
-    #         rsp = self.client.get(url)
-    #         self.assertEqual(
-    #             'text/plain; charset="utf-8"',
-    #             rsp._headers["content-type"][1]
-    #         )
-    #         self.assertEqual(200, rsp.status_code)
-    #         self.assertGreater(len(rsp.content.decode()), 0)
-    #     lc = LegalCodeFactory(
-    #         tool__version="3.0",
-    #         language_code="fr",
-    #         tool__unit="by",
-    #         tool__jurisdiction_code="ch",
-    #     )
-    #     url = lc.plain_text_url
-    #     rsp = self.client.get(url)
-    #     self.assertEqual(
-    #         'text/plain; charset="utf-8"', rsp._headers["content-type"][1]
-    #     )
-    #     self.assertEqual(200, rsp.status_code)
-    #     self.assertGreater(len(rsp.content.decode()), 0)
 
     def test_legal_code_translation_by_40_es(self):
         language_code = "es"

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -848,6 +848,9 @@ class ViewLegalCodeTest(TestCase):
             self.assertContains(
                 rsp, f'href="legalcode.{language_code}.md"'
             )
+            self.assertContains(
+                rsp, f'href="legalcode.{language_code}.txt"'
+            )
             if language_code == "es":
                 self.assertContains(rsp, 'dir="ltr"')
             elif language_code == "ar":
@@ -1487,20 +1490,84 @@ class ViewLegalToolRdf(ToolsTestsMixin, TestCase):
                 )
 
 
-class ViewLegacyPlaintext(ToolsTestsMixin, TestCase):
-    def test_view_legacy_plaintext_file_exists(self):
+class ViewLegalCodePlaintext(ToolsTestsMixin, TestCase):
+    def test_view_plaintext_file_exists_for_language(self):
+        tool = Tool.objects.get(unit="by", version="4.0")
+        url = build_path(base_url=tool.base_url, document="legalcode")
+        url = f"{url}.{settings.LANGUAGE_CODE}.txt"
+        response = self.client.get(url)
+        content = response.content.decode()
+        self.assertEqual(f"{response.status_code} {url}", f"200 {url}")
+        self.assertEqual(
+            response.headers["Content-Type"], "text/plain; charset=utf-8"
+        )
+        lines = content.splitlines()
+        self.assertEqual("Attribution 4.0 International", lines[0])
+        self.assertEqual(3, lines.count("=" * 70))
+        self.assertEqual(2, lines.count("Attribution 4.0 International"))
+        self.assertIn("About the license and Creative Commons", content)
+        self.assertIn("Using Creative Commons Public Licenses", content)
+        self.assertIn("  a. Adapted Material means", content)
+
+    def test_view_plaintext_translated_file_exists(self):
+        tool = Tool.objects.get(unit="by", version="4.0")
+        legal_code, _ = LegalCode.objects.update_or_create(
+            tool=tool,
+            language_code="zh-hant",
+            defaults={"title": "姓名標示 4.0 國際"},
+        )
+        url = f"{legal_code.legal_code_url}.txt"
+
+        response = self.client.get(url)
+        content = response.content.decode()
+
+        self.assertEqual(f"{response.status_code} {url}", f"200 {url}")
+        self.assertEqual(
+            response.headers["Content-Type"], "text/plain; charset=utf-8"
+        )
+        self.assertIn("姓名標示 4.0 國際", content)
+
+    def test_view_plaintext_ported_file_exists(self):
+        legal_code = LegalCodeFactory(
+            html="<p><strong>Legacy</strong> body</p>",
+            language_code="de",
+            title="Legacy Title",
+            tool__category="licenses",
+            tool__base_url="https://creativecommons.org"
+            "/licenses/by/3.0/de/",
+            tool__unit="by",
+            tool__version="3.0",
+            tool__jurisdiction_code="de",
+        )
+        url = f"{legal_code.legal_code_url}.txt"
+
+        response = self.client.get(url)
+        content = response.content.decode()
+
+        self.assertEqual(f"{response.status_code} {url}", f"200 {url}")
+        self.assertEqual(
+            response.headers["Content-Type"], "text/plain; charset=utf-8"
+        )
+        self.assertIn("Namensnennung 3.0 Deutschland", content)
+        self.assertIn("Legacy body", content)
+
+    def test_view_plaintext_unsuffixed_file_does_not_exist(self):
         tool = Tool.objects.get(unit="by", version="4.0")
         url = build_path(base_url=tool.base_url, document="legalcode")
         url = f"{url}.txt"
         response = self.client.get(url)
-        content = response.content.decode()
-        self.assertEqual(f"{response.status_code} {url}", f"200 {url}")
-        self.assertEqual(response.headers["Content-Type"], "text/plain")
-        self.assertIn("Attribution 4.0 International", content)
+        self.assertEqual(f"{response.status_code} {url}", f"404 {url}")
 
-    def test_view_legacy_plaintext_file_does_not_exist(self):
-        tool = Tool.objects.get(unit="by", version="2.0")
-        url = build_path(base_url=tool.base_url, document="legalcode")
-        url = f"{url}.txt"
+    def test_view_plaintext_deed_only_file_does_not_exist(self):
+        legal_code = LegalCodeFactory(
+            language_code=settings.LANGUAGE_CODE,
+            tool__category="publicdomain",
+            tool__base_url="https://creativecommons.org"
+            "/publicdomain/mark/1.0/",
+            tool__deed_only=True,
+            tool__unit="mark",
+            tool__version="1.0",
+        )
+        url = f"{legal_code.legal_code_url}.txt"
         response = self.client.get(url)
         self.assertEqual(f"{response.status_code} {url}", f"404 {url}")

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -873,7 +873,8 @@ class ViewLegalCodeTest(TestCase):
         self.assertEqual(
             rsp.headers["Content-Type"], "text/markdown; charset=utf-8"
         )
-        self.assertIn("## Attribution 4.0 International", content)
+        self.assertIn("# Attribution 4.0 International\n", content)
+        self.assertNotIn("## Attribution 4.0 International", content)
         self.assertIn("Section 1", content)
         self.assertIn("(a) <u>Adapted Material</u>", content)
         self.assertNotIn("1. (a)", content)
@@ -897,7 +898,8 @@ class ViewLegalCodeTest(TestCase):
         content = rsp.content.decode("utf-8")
 
         self.assertEqual(f"{rsp.status_code} {url}", f"200 {url}")
-        self.assertIn("## Attribution 4.0 International", content)
+        self.assertIn("# Attribution 4.0 International\n", content)
+        self.assertNotIn("## Attribution 4.0 International", content)
 
     def test_view_legal_code_markdown_legacy_raw_html(self):
         legal_code = LegalCodeFactory(
@@ -920,7 +922,8 @@ class ViewLegalCodeTest(TestCase):
         self.assertEqual(
             rsp.headers["Content-Type"], "text/markdown; charset=utf-8"
         )
-        self.assertIn("## Legacy Title", content)
+        self.assertIn("# Legacy Title\n", content)
+        self.assertNotIn("## Legacy Title", content)
         self.assertIn("**Legacy** body", content)
 
     def test_view_legal_code_markdown_deed_only_404(self):

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -1505,8 +1505,17 @@ class ViewLegalCodePlaintext(ToolsTestsMixin, TestCase):
         self.assertEqual("Attribution 4.0 International", lines[0])
         self.assertEqual(3, lines.count("=" * 71))
         self.assertEqual(2, lines.count("Attribution 4.0 International"))
-        self.assertIn("About the license and Creative Commons", content)
+        self.assertNotIn("About the license and Creative Commons", content)
+        self.assertNotIn("About Creative Commons", content)
         self.assertIn("Using Creative Commons Public Licenses", content)
+        self.assertIn(
+            'Creative Commons Corporation ("Creative Commons") is not a law',
+            content,
+        )
+        self.assertIn(
+            "Creative Commons public licenses provide a standard set of terms",
+            content,
+        )
         self.assertIn("  a. Adapted Material means", content)
 
     def test_view_plaintext_translated_file_exists(self):

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -1503,7 +1503,7 @@ class ViewLegalCodePlaintext(ToolsTestsMixin, TestCase):
         )
         lines = content.splitlines()
         self.assertEqual("Attribution 4.0 International", lines[0])
-        self.assertEqual(3, lines.count("=" * 70))
+        self.assertEqual(3, lines.count("=" * 71))
         self.assertEqual(2, lines.count("Attribution 4.0 International"))
         self.assertIn("About the license and Creative Commons", content)
         self.assertIn("Using Creative Commons Public Licenses", content)

--- a/legal_tools/tests/test_views.py
+++ b/legal_tools/tests/test_views.py
@@ -873,13 +873,20 @@ class ViewLegalCodeTest(TestCase):
         self.assertEqual(
             rsp.headers["Content-Type"], "text/markdown; charset=utf-8"
         )
-        self.assertIn("# Attribution 4.0 International\n", content)
-        self.assertNotIn("## Attribution 4.0 International", content)
-        self.assertIn("Section 1", content)
-        self.assertIn("(a) <u>Adapted Material</u>", content)
+        lines = content.splitlines()
+        self.assertEqual("# Attribution 4.0 International", lines[0])
+        self.assertEqual(1, lines.count("# Attribution 4.0 International"))
+        self.assertEqual(1, lines.count("## Attribution 4.0 International"))
+        self.assertIn("### Section 1", content)
+        self.assertIn("<u>Adapted Material</u> means", content)
         self.assertNotIn("1. (a)", content)
         self.assertNotIn("<html", content)
-        self.assertNotIn("About the license and Creative Commons", content)
+        self.assertIn("## About the license and Creative Commons", content)
+        self.assertIn("## Using Creative Commons Public Licenses", content)
+        self.assertIn("### Considerations for licensors", content)
+        self.assertIn("### Considerations for the public", content)
+        self.assertIn("## About Creative Commons", content)
+        self.assertNotIn("Learn more about our work", content)
 
     def test_view_legal_code_markdown_40_default_language(self):
         tool = ToolFactory(
@@ -898,8 +905,10 @@ class ViewLegalCodeTest(TestCase):
         content = rsp.content.decode("utf-8")
 
         self.assertEqual(f"{rsp.status_code} {url}", f"200 {url}")
-        self.assertIn("# Attribution 4.0 International\n", content)
-        self.assertNotIn("## Attribution 4.0 International", content)
+        lines = content.splitlines()
+        self.assertEqual("# Attribution 4.0 International", lines[0])
+        self.assertEqual(1, lines.count("# Attribution 4.0 International"))
+        self.assertEqual(1, lines.count("## Attribution 4.0 International"))
 
     def test_view_legal_code_markdown_legacy_raw_html(self):
         legal_code = LegalCodeFactory(
@@ -922,9 +931,15 @@ class ViewLegalCodeTest(TestCase):
         self.assertEqual(
             rsp.headers["Content-Type"], "text/markdown; charset=utf-8"
         )
-        self.assertIn("# Legacy Title\n", content)
-        self.assertNotIn("## Legacy Title", content)
+        lines = content.splitlines()
+        self.assertEqual("# Namensnennung 3.0 Deutschland", lines[0])
+        self.assertEqual(1, lines.count("# Namensnennung 3.0 Deutschland"))
+        self.assertEqual(0, lines.count("# Legacy Title"))
+        self.assertEqual(1, lines.count("## Legacy Title"))
         self.assertIn("**Legacy** body", content)
+        self.assertIn("## About Creative Commons", content)
+        self.assertNotIn("About the license and Creative Commons", content)
+        self.assertNotIn("Using Creative Commons Public Licenses", content)
 
     def test_view_legal_code_markdown_deed_only_404(self):
         legal_code = LegalCodeFactory(

--- a/legal_tools/urls.py
+++ b/legal_tools/urls.py
@@ -19,7 +19,6 @@ from legal_tools.views import (
     view_deed,
     view_dev_index,
     view_image_rdf,
-    view_legacy_plaintext,
     view_legal_code,
     view_legal_tool_rdf,
     view_list,
@@ -247,20 +246,24 @@ urlpatterns = [
         name="view_deed_unported",
     ),
     # LEGALCODE PAGES #########################################################
-    # Legalcode: plain text
+    # Plaintext Legalcode: with Jurisdiction (ported), with language_code
     path(
-        "<category:category>/<unit:unit>/<version:version>/legalcode.txt",
-        view_legacy_plaintext,
-        name="view_legacy_plaintext",
+        "<category:category>/<unit:unit>/<version:version>"
+        "/<jurisdiction:jurisdiction>/legalcode"
+        ".<language_code:language_code>.txt",
+        view_legal_code,
+        kwargs=dict(is_plain_text=True),
+        name="view_legal_code_plaintext_ported_language_specified",
     ),
-    # NOTE: programmatic plaintext functionality disabled
-    # # Plaintext Legalcode: no Jurisdiction (int/unported), no language_code
-    # path(
-    #     "<category:category>/<unit:unit>/<version:version>/legalcode.txt",
-    #     view_legal_code,
-    #     kwargs=dict(jurisdiction="", is_plain_text=True),
-    #     name="view_legal_code_unported",
-    # ),
+    # Plaintext Legalcode: no Jurisdiction (international/unported),
+    # with language_code
+    path(
+        "<category:category>/<unit:unit>/<version:version>/legalcode"
+        ".<language_code:language_code>.txt",
+        view_legal_code,
+        kwargs=dict(jurisdiction="", is_plain_text=True),
+        name="view_legal_code_plaintext_unported_language_specified",
+    ),
     # Markdown Legalcode: with Jurisdiction (ported), with language_code
     path(
         "<category:category>/<unit:unit>/<version:version>"

--- a/legal_tools/urls.py
+++ b/legal_tools/urls.py
@@ -261,6 +261,40 @@ urlpatterns = [
     #     kwargs=dict(jurisdiction="", is_plain_text=True),
     #     name="view_legal_code_unported",
     # ),
+    # Markdown Legalcode: with Jurisdiction (ported), with language_code
+    path(
+        "<category:category>/<unit:unit>/<version:version>"
+        "/<jurisdiction:jurisdiction>/legalcode"
+        ".<language_code:language_code>.md",
+        view_legal_code,
+        kwargs=dict(is_markdown=True),
+        name="view_legal_code_markdown_ported_language_specified",
+    ),
+    # Markdown Legalcode: with Jurisdiction (ported), no language_code
+    path(
+        "<category:category>/<unit:unit>/<version:version>"
+        "/<jurisdiction:jurisdiction>/legalcode.md",
+        view_legal_code,
+        kwargs=dict(is_markdown=True),
+        name="view_legal_code_markdown_ported",
+    ),
+    # Markdown Legalcode: no Jurisdiction (international/unported),
+    # with language_code
+    path(
+        "<category:category>/<unit:unit>/<version:version>/legalcode"
+        ".<language_code:language_code>.md",
+        view_legal_code,
+        kwargs=dict(jurisdiction="", is_markdown=True),
+        name="view_legal_code_markdown_unported_language_specified",
+    ),
+    # Markdown Legalcode: no Jurisdiction (international/unported),
+    # no language_code
+    path(
+        "<category:category>/<unit:unit>/<version:version>/legalcode.md",
+        view_legal_code,
+        kwargs=dict(jurisdiction="", is_markdown=True),
+        name="view_legal_code_markdown_unported",
+    ),
     # Legalcode: with Jurisdiction (ported), with language_code
     path(
         "<category:category>/<unit:unit>/<version:version>"

--- a/legal_tools/utils.py
+++ b/legal_tools/utils.py
@@ -322,7 +322,7 @@ def get_tool_title(unit, version, category, jurisdiction, language_code):
         )
     except legal_tools.models.LegalCode.DoesNotExist:
         legal_code = False
-    if legal_code:
+    if legal_code and not legal_code.html:
         tool_title_db = clean_string(legal_code.title)
         if tool_title_db and tool_title_db != tool_title_en:
             tool_title = tool_title_db

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -20,6 +20,7 @@ from i18n.utils import (
     load_deeds_ux_translations,
     map_django_to_transifex_language_code,
 )
+from legal_tools.markdown_utils import legal_code_html_to_markdown
 from legal_tools.models import (
     UNITS_LICENSES,
     LegalCode,
@@ -395,8 +396,11 @@ def view_legal_code(
     jurisdiction=None,
     language_code=None,
     is_plain_text=False,
+    is_markdown=False,
 ):
     plain_text_url = None
+    if is_markdown and request.path.endswith(".md"):
+        request.path = request.path[:-3]
     request.path, language_code = normalize_path_and_lang(
         request.path, jurisdiction, language_code
     )
@@ -435,6 +439,8 @@ def view_legal_code(
     else:
         translation.activate(settings.LANGUAGE_CODE)
     tool = legal_code.tool
+    if is_markdown and tool.deed_only:
+        raise Http404("Markdown legalcode does not exist for deed-only tools")
 
     # get_tool_title manipulates the translation domain and, therefore, MUST
     # be called before we Activate Legal Code translation
@@ -472,6 +478,10 @@ def view_legal_code(
 
         if tool.identifier() in PLAIN_TEXT_TOOL_IDENTIFIERS:
             plain_text_url = "legalcode.txt"
+        if tool.deed_only:
+            markdown_url = None
+        else:
+            markdown_url = f"legalcode.{language_code}.md"
 
         canonical_url_html = os.path.join(
             settings.CANONICAL_SITE, request.path.lstrip(os.sep)
@@ -493,6 +503,7 @@ def view_legal_code(
                 "legal_code": legal_code,
                 "list_licenses": list_licenses,
                 "list_publicdomain": list_publicdomain,
+                "markdown_url": markdown_url,
                 "plain_text_url": plain_text_url,
                 "replaced_path": replaced_path,
                 "replaced_title": replaced_title,
@@ -527,6 +538,18 @@ def view_legal_code(
         #         response.write(output.stdout)
         #         return response
         #
+        if is_markdown:
+            html_content = render_to_string(
+                template_name="legalcode_body.html",
+                context=kwargs["context"],
+                request=request,
+            )
+            markdown_content = legal_code_html_to_markdown(html_content)
+            return HttpResponse(
+                markdown_content,
+                content_type="text/markdown; charset=utf-8",
+            )
+
         html_response = render(request, **kwargs)
         html_response.content = pretty_html_bytes(
             request.path, html_response.content

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -540,7 +540,7 @@ def view_legal_code(
         #
         if is_markdown:
             html_content = render_to_string(
-                template_name="legalcode_body.html",
+                template_name="legalcode_document.html",
                 context=kwargs["context"],
                 request=request,
             )

--- a/legal_tools/views.py
+++ b/legal_tools/views.py
@@ -27,6 +27,7 @@ from legal_tools.models import (
     Tool,
     TranslationBranch,
 )
+from legal_tools.plaintext_utils import legal_code_html_to_plain_text
 from legal_tools.rdf_utils import (
     generate_images_rdf,
     generate_legal_code_rdf,
@@ -45,21 +46,6 @@ from legal_tools.view_utils import (
 )
 
 NUM_COMMITS = 3
-PLAIN_TEXT_TOOL_IDENTIFIERS = [
-    "CC BY 3.0",
-    "CC BY-NC 3.0",
-    "CC BY-NC-ND 3.0",
-    "CC BY-NC-SA 3.0",
-    "CC BY-ND 3.0",
-    "CC BY-SA 3.0",
-    "CC BY 4.0",
-    "CC BY-NC 4.0",
-    "CC BY-NC-ND 4.0",
-    "CC BY-NC-SA 4.0",
-    "CC BY-ND 4.0",
-    "CC BY-SA 4.0",
-    "CC0 1.0",
-]
 
 
 def view_dev_index(request):
@@ -399,6 +385,8 @@ def view_legal_code(
     is_markdown=False,
 ):
     plain_text_url = None
+    if is_plain_text and request.path.endswith(".txt"):
+        request.path = request.path[:-4]
     if is_markdown and request.path.endswith(".md"):
         request.path = request.path[:-3]
     request.path, language_code = normalize_path_and_lang(
@@ -414,18 +402,6 @@ def view_legal_code(
 
     path_start = os.path.dirname(request.path)
 
-    # NOTE: plaintext functionality disabled
-    # if is_plain_text:
-    #     legal_code = get_object_or_404(
-    #         LegalCode,
-    #         plain_text_url=request.path,
-    #     )
-    # else:
-    #     legal_code = get_object_or_404(
-    #         LegalCode,
-    #         legal_code_url=request.path,
-    #     )
-
     legal_code = get_object_or_404(
         LegalCode,
         legal_code_url=request.path,
@@ -439,6 +415,8 @@ def view_legal_code(
     else:
         translation.activate(settings.LANGUAGE_CODE)
     tool = legal_code.tool
+    if is_plain_text and not legal_code.get_plaintext_publish_file():
+        raise Http404("Plain text legalcode does not exist for this tool")
     if is_markdown and tool.deed_only:
         raise Http404("Markdown legalcode does not exist for deed-only tools")
 
@@ -476,12 +454,12 @@ def view_legal_code(
             language_default,
         )
 
-        if tool.identifier() in PLAIN_TEXT_TOOL_IDENTIFIERS:
-            plain_text_url = "legalcode.txt"
         if tool.deed_only:
             markdown_url = None
+            plain_text_url = None
         else:
             markdown_url = f"legalcode.{language_code}.md"
+            plain_text_url = f"legalcode.{language_code}.txt"
 
         canonical_url_html = os.path.join(
             settings.CANONICAL_SITE, request.path.lstrip(os.sep)
@@ -512,32 +490,18 @@ def view_legal_code(
             },
         )
 
-        # NOTE: plaintext functionality disabled
-        # if is_plain_text:
-        #     response = HttpResponse(
-        #         content_type='text/plain; charset="utf-8"'
-        #     )
-        #     html = render_to_string(**kwargs)
-        #     soup = BeautifulSoup(html, "lxml")
-        #     plain_text_soup = soup.find(id="plain-text-marker")
-        #     # FIXME: prune the "img" tags from this before saving again.
-        #     with tempfile.NamedTemporaryFile(mode="w+b") as temp:
-        #         temp.write(plain_text_soup.encode("utf-8"))
-        #         output = subprocess.run(
-        #             [
-        #                 "pandoc",
-        #                 "-f",
-        #                 "html",
-        #                 temp.name,
-        #                 "-t",
-        #                 "plain",
-        #             ],
-        #             encoding="utf-8",
-        #             capture_output=True,
-        #         )
-        #         response.write(output.stdout)
-        #         return response
-        #
+        if is_plain_text:
+            html_content = render_to_string(
+                template_name="legalcode_document.html",
+                context=kwargs["context"],
+                request=request,
+            )
+            plaintext_content = legal_code_html_to_plain_text(html_content)
+            return HttpResponse(
+                plaintext_content,
+                content_type="text/plain; charset=utf-8",
+            )
+
         if is_markdown:
             html_content = render_to_string(
                 template_name="legalcode_document.html",
@@ -719,31 +683,4 @@ def view_image_rdf(request):
     response = HttpResponse(
         serialized_rdf_content, content_type="application/rdf+xml"
     )
-    return response
-
-
-def view_legacy_plaintext(
-    request,
-    unit,
-    version,
-    category=None,
-):
-    """
-    Display plain text file, if it exists.
-
-    (This view is only used in development.)
-    """
-    published_docs_path = os.path.abspath(
-        os.path.realpath(os.path.join("..", "cc-legal-tools-data", "docs"))
-    )
-    plain_text_path = os.path.join(
-        published_docs_path, request.path.lstrip(os.sep)
-    )
-    if os.path.isfile(plain_text_path):
-        with open(plain_text_path, "rt") as file_obj:
-            content = file_obj.read()
-        response = HttpResponse(content, content_type="text/plain")
-    else:
-        raise Http404("plain text file does not exist")
-
     return response

--- a/templates/legalcode.html
+++ b/templates/legalcode.html
@@ -40,6 +40,9 @@
 {% if plain_text_url %}
 <li><a href="{{ plain_text_url }}">{% trans "Plain Text" %}</a></li>
 {% endif %}
+{% if markdown_url %}
+<li><a href="{{ markdown_url }}">{% trans "Markdown" %}</a></li>
+{% endif %}
 <li><a href="rdf">RDF/XML</a></li>
 </ul>
 </article>
@@ -73,22 +76,8 @@ the date of change
 {% if not legal_code.html %}
   {% include 'includes/notice_about_licenses_and_cc.html' %} {# CC IS NOT A LAW FIRM #}
   {% include 'includes/use_of_licenses.html' %} {# Considerations... #}
-  {% if tool.category == "publicdomain" and tool.unit == "zero" %}
-    {% include 'includes/legalcode_zero.html' %} {# <<< THE ACTUAL CC0 LICENSE TEXT #}
-  {% elif tool.category == "licenses" and tool.version == "4.0" %}
-    {% include 'includes/legalcode_licenses_4.0.html' %} {# <<< THE ACTUAL 4.0 LICENSE TEXT #}
-  {% elif tool.category == "licenses" and tool.version == "3.0" and not tool.jurisdiction_code %}
-    {% include 'includes/legalcode_licenses_3.0_unported.html' %} {# <<< THE ACTUAL 3.0 unported LICENSE TEXT #}
-  {% else %}
-    <div id="legal-code-body" class="padding-larger margin-top-bigger has-text-black    ">
-      <p class="has-text-black body-big padding-bottom-normal"><strong>{% trans "Unimplemented" %}</strong> &mdash; {% blocktrans %}this legal tool does not have a valid template. Please report this issue:{% endblocktrans %} <a href="https://github.com/creativecommons/cc-legal-tools-app/issues">Issues · creativecommons/cc-legal-tools-app</a>.</p>
-    </div>
-  {% endif %}
-  {# NOTE: plaintext functionality disabled #}
-  {# {% include 'includes/view_legal_code_link_plain_text.html' %} #}
-{% else %}
-  {% include "includes/legalcode_crude_html.html" %}
 {% endif %}
+{% include "legalcode_body.html" %}
 {% include 'includes/notice_about_cc_and_trademark.html' %}
 {% include 'includes/related_links.html' %}
 

--- a/templates/legalcode_body.html
+++ b/templates/legalcode_body.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% if not legal_code.html %}
+  {% if tool.category == "publicdomain" and tool.unit == "zero" %}
+    {% include 'includes/legalcode_zero.html' %}
+  {% elif tool.category == "licenses" and tool.version == "4.0" %}
+    {% include 'includes/legalcode_licenses_4.0.html' %}
+  {% elif tool.category == "licenses" and tool.version == "3.0" and not tool.jurisdiction_code %}
+    {% include 'includes/legalcode_licenses_3.0_unported.html' %}
+  {% else %}
+    <div id="legal-code-body" class="padding-larger margin-top-bigger has-text-black">
+      <p class="has-text-black body-big padding-bottom-normal">
+        <strong>{% trans "Unimplemented" %}</strong> &mdash;
+        {% blocktrans %}this legal tool does not have a valid template. Please report this issue:{% endblocktrans %}
+        <a href="https://github.com/creativecommons/cc-legal-tools-app/issues">Issues - creativecommons/cc-legal-tools-app</a>.
+      </p>
+    </div>
+  {% endif %}
+{% else %}
+  {% include "includes/legalcode_crude_html.html" %}
+{% endif %}
+{# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}

--- a/templates/legalcode_document.html
+++ b/templates/legalcode_document.html
@@ -1,0 +1,10 @@
+<div id="legal-code-document">
+<h1>{{ tool_title }}</h1>
+{% if not legal_code.html %}
+  {% include 'includes/notice_about_licenses_and_cc.html' %}
+  {% include 'includes/use_of_licenses.html' %}
+{% endif %}
+{% include "legalcode_body.html" %}
+{% include 'includes/notice_about_cc_and_trademark.html' %}
+</div>
+{# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #547 by @bogdan-barbu
- Fixes #289 by @little-wow
- Fixes #286
- Fixes #384 by @mmoreshead

## Description
<!-- Concisely describe what the pull request does. -->
This publishes Markdown files from the generated HTML files since those are the source of truth. Each page links to the Markdown file for its language. Also added tests. I have not touched the plain text hack.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
There's a stylistic choice I made for numbered lists. Markdown only supports decimal numbers but the licenses contain lists numbered with roman numerals or letters. One choice would have been to use embedded HTML tags. Instead I opted for regular text for these special cases because it makes the content a bit more human-readable. But as far as Markdown is concerned those aren't really lists. Proper nesting is simulated with `&nbsp;`s since leading spaces would turn those lines into code blocks.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
I would use `./bin/publish.sh --filter-license-markdown 4.0` (or `--fm 4.0`) to generate a sample license batch. The equivalent for plain text is `--filter-license-text 4.0` (or `--ft 4.0`). This is all documented in `README.md`.

<!-- ## Screenshots -->
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>