### PR TITLE
App: adjust padding and long hyperlink wrapping on deed pages

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/deed.css
+++ b/cc_legal_tools/static/cc-legal-tools/deed.css
@@ -113,6 +113,4 @@
     .cc-legal-tools.bidi-left div#deed-body ol > li {
       padding-left: 0;
     }
-
 }
-

--- a/cc_legal_tools/static/cc-legal-tools/deed.css
+++ b/cc_legal_tools/static/cc-legal-tools/deed.css
@@ -91,3 +91,28 @@
   display: inline-block;
   text-indent: -3000px;
 }
+
+@media (max-width: 578px) {
+
+    .legal-tools .tool-meta {
+      padding: 1em;
+    }
+
+    .cc-legal-tools .tool-meta {
+      word-break: break-word;
+    }
+
+    .cc-legal-tools .tool-meta div.meta-box {
+      width: 90%;
+    }
+
+    .legal-tools div.content div#deed-body {
+      padding: 1em;
+    }
+
+    .cc-legal-tools.bidi-left div#deed-body ol > li {
+      padding-left: 0;
+    }
+
+}
+


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->

## Description
App: adjust padding and long hyperlink wrapping on deed pages
- fixes creativecommons/tech-support/issues/1483 _(private repo)_
- enables line wrapping of longer hyperlinks that attempt to break bounds of container on deed pages
- adjusts overall padding on content areas and sidebar on deed pages to improve readability
- also see related Data pull request:
  - creativecommons/cc-legal-tools-data/pull/293

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
1. Open any Deed Page
2. Shrink window to at least 578px wide
3. See results.

### Unit tests and coverage
command:
```shell
./bin/coverage.sh
```
output excerpt:
```
Name    Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------
TOTAL    1824      0    592      0  100.00%

21 files skipped due to complete coverage.
```


## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

### Before
<img width="281" height="609" alt="Screen Shot 2026-07-22 at 9 18 34 AM" src="https://github.com/user-attachments/assets/f7f99516-520a-47bd-ae22-0714458190f8" />


### After
<img width="365" height="539" alt="Screen Shot 2026-07-22 at 9 45 07 AM" src="https://github.com/user-attachments/assets/8e9b7d41-d05f-43c0-b5a5-fa5cf56a17ea" />


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
