### PR TITLE
Fix custom currency icons for deeds (#74)

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/deed.css
+++ b/cc_legal_tools/static/cc-legal-tools/deed.css
@@ -52,6 +52,12 @@
 .cc-legal-tools div#deed-body ol > li.cc-nc:before {
   background-image: url("/wp-content/themes/vocabulary-theme/vocabulary/svg/cc/icons/cc-icons.svg#cc-nc");
 }
+.cc-legal-tools div#deed-body ol > li.cc-nc-eu:before {
+  background-image: url("/wp-content/themes/vocabulary-theme/vocabulary/svg/cc/icons/cc-icons.svg#cc-nc-eu");
+}
+.cc-legal-tools div#deed-body ol > li.cc-nc-jp:before {
+  background-image: url("/wp-content/themes/vocabulary-theme/vocabulary/svg/cc/icons/cc-icons.svg#cc-nc-jp");
+}
 .cc-legal-tools div#deed-body ol > li.cc-nd:before {
   background-image: url("/wp-content/themes/vocabulary-theme/vocabulary/svg/cc/icons/cc-icons.svg#cc-nd");
 }

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -1,5 +1,4 @@
 # Standard library
-import os
 import posixpath
 
 # Third-party
@@ -12,6 +11,7 @@ from django.utils import translation
 # First-party/Local
 from i18n import LANGMAP_DJANGO_TO_PCRE
 from i18n.utils import (
+    JURISDICTION_CURRENCY_LOOKUP,
     get_default_language_for_jurisdiction_deed,
     get_default_language_for_jurisdiction_naive,
     get_jurisdiction_name,
@@ -261,7 +261,7 @@ class LegalCode(models.Model):
         if self.tool.deed_only:
             relpath = None
         else:
-            relpath = os.path.join(tool._get_save_path(), filename)
+            relpath = posixpath.join(tool._get_save_path(), filename)
 
         # Symlinks
         symlinks = []
@@ -275,7 +275,7 @@ class LegalCode(models.Model):
         if self.tool.deed_only:
             redirects_data.append(
                 {
-                    "redirect_file": os.path.join(
+                    "redirect_file": posixpath.join(
                         tool._get_save_path(),
                         f"legalcode.{language_code}.html",
                     ),
@@ -286,7 +286,7 @@ class LegalCode(models.Model):
             )
             redirects_data.append(
                 {
-                    "redirect_file": os.path.join(
+                    "redirect_file": posixpath.join(
                         tool._get_save_path(), "legalcode.html"
                     ),
                     "title": self.title,
@@ -301,10 +301,10 @@ class LegalCode(models.Model):
         language_code = self.language_code
         tool = self.tool
         filename = f"legalcode.{language_code}"
-        dest_path = os.path.join("/", tool._get_save_path(), filename)
+        dest_path = posixpath.join("/", tool._get_save_path(), filename)
         pairs = []
         for pcre in LANGMAP_DJANGO_TO_PCRE.get(language_code, []):
-            pcre_match = os.path.join(
+            pcre_match = posixpath.join(
                 "/",
                 tool._get_save_path().replace(".", "[.]"),
                 f"legalcode[.]{pcre}(?:[.]html)?",
@@ -532,7 +532,7 @@ class Tool(models.Model):
         unit = self.unit.lower()
         if self.jurisdiction_code:
             # ported Licenses 3.0 and earlier
-            return os.path.join(
+            return posixpath.join(
                 self.category,  # licenses or publicdomain
                 unit,  # ex. by, by-nc-nd
                 self.version,  # ex. 1.0, 2.0
@@ -540,7 +540,7 @@ class Tool(models.Model):
             )
         else:
             # unported Licenses 3.0, Licenses 4.0, and Public Domain:
-            return os.path.join(
+            return posixpath.join(
                 self.category,  # licenses or publicdomain
                 unit,  # ex. by, by-nc-nd, zero
                 self.version,  # ex. 1.0, 4.0
@@ -641,7 +641,7 @@ class Tool(models.Model):
         filename = f"deed.{language_code}.html"
 
         # Relative path
-        relpath = os.path.join(self._get_save_path(), filename)
+        relpath = posixpath.join(self._get_save_path(), filename)
 
         # Symlinks
         symlinks = []
@@ -654,16 +654,27 @@ class Tool(models.Model):
 
     def get_redirect_pairs(self, language_code):
         filename = f"deed.{language_code}"
-        dest_path = os.path.join("/", self._get_save_path(), filename)
+        dest_path = posixpath.join("/", self._get_save_path(), filename)
         pairs = []
         for pcre in LANGMAP_DJANGO_TO_PCRE.get(language_code, []):
-            pcre_match = os.path.join(
+            pcre_match = posixpath.join(
                 "/",
                 self._get_save_path().replace(".", "[.]"),
                 f"deed[.]{pcre}(?:[.]html)?",
             )
             pairs.append([pcre_match, dest_path])
         return pairs
+
+    @property
+    def nc_symbol(self):
+        """
+        Return the non-commercial symbol variant for this tool based
+        on jurisdiction. Returns 'cc-nc-eu', 'cc-nc-jp', or 'cc-nc'.
+        """
+        currency = JURISDICTION_CURRENCY_LOOKUP.get(self.jurisdiction_code)
+        if currency:
+            return f"cc-nc-{currency}"
+        return "cc-nc"
 
     def logos(self):
         """
@@ -679,14 +690,17 @@ class Tool(models.Model):
         elif self.unit == "sampling+":
             result.append("cc-sampling-plus")
         elif self.unit == "nc-sampling+":
-            result.append("cc-nc")
+            result.append(self.nc_symbol)
             result.append("cc-sampling-plus")
         elif self.unit == "zero":
             result.append("cc-zero")
         else:
             for unit_part in self.unit.split("-"):
                 if unit_part in ["by", "nc", "nd", "sa"]:
-                    result.append(f"cc-{unit_part}")
+                    if unit_part == "nc":
+                        result.append(self.nc_symbol)
+                    else:
+                        result.append(f"cc-{unit_part}")
         return result
 
     @property

--- a/legal_tools/models.py
+++ b/legal_tools/models.py
@@ -1,4 +1,5 @@
 # Standard library
+import os
 import posixpath
 
 # Third-party
@@ -261,7 +262,7 @@ class LegalCode(models.Model):
         if self.tool.deed_only:
             relpath = None
         else:
-            relpath = posixpath.join(tool._get_save_path(), filename)
+            relpath = os.path.join(tool._get_save_path(), filename)
 
         # Symlinks
         symlinks = []
@@ -275,7 +276,7 @@ class LegalCode(models.Model):
         if self.tool.deed_only:
             redirects_data.append(
                 {
-                    "redirect_file": posixpath.join(
+                    "redirect_file": os.path.join(
                         tool._get_save_path(),
                         f"legalcode.{language_code}.html",
                     ),
@@ -286,7 +287,7 @@ class LegalCode(models.Model):
             )
             redirects_data.append(
                 {
-                    "redirect_file": posixpath.join(
+                    "redirect_file": os.path.join(
                         tool._get_save_path(), "legalcode.html"
                     ),
                     "title": self.title,
@@ -301,10 +302,10 @@ class LegalCode(models.Model):
         language_code = self.language_code
         tool = self.tool
         filename = f"legalcode.{language_code}"
-        dest_path = posixpath.join("/", tool._get_save_path(), filename)
+        dest_path = os.path.join("/", tool._get_save_path(), filename)
         pairs = []
         for pcre in LANGMAP_DJANGO_TO_PCRE.get(language_code, []):
-            pcre_match = posixpath.join(
+            pcre_match = os.path.join(
                 "/",
                 tool._get_save_path().replace(".", "[.]"),
                 f"legalcode[.]{pcre}(?:[.]html)?",
@@ -532,7 +533,7 @@ class Tool(models.Model):
         unit = self.unit.lower()
         if self.jurisdiction_code:
             # ported Licenses 3.0 and earlier
-            return posixpath.join(
+            return os.path.join(
                 self.category,  # licenses or publicdomain
                 unit,  # ex. by, by-nc-nd
                 self.version,  # ex. 1.0, 2.0
@@ -540,7 +541,7 @@ class Tool(models.Model):
             )
         else:
             # unported Licenses 3.0, Licenses 4.0, and Public Domain:
-            return posixpath.join(
+            return os.path.join(
                 self.category,  # licenses or publicdomain
                 unit,  # ex. by, by-nc-nd, zero
                 self.version,  # ex. 1.0, 4.0
@@ -641,7 +642,7 @@ class Tool(models.Model):
         filename = f"deed.{language_code}.html"
 
         # Relative path
-        relpath = posixpath.join(self._get_save_path(), filename)
+        relpath = os.path.join(self._get_save_path(), filename)
 
         # Symlinks
         symlinks = []
@@ -654,10 +655,10 @@ class Tool(models.Model):
 
     def get_redirect_pairs(self, language_code):
         filename = f"deed.{language_code}"
-        dest_path = posixpath.join("/", self._get_save_path(), filename)
+        dest_path = os.path.join("/", self._get_save_path(), filename)
         pairs = []
         for pcre in LANGMAP_DJANGO_TO_PCRE.get(language_code, []):
-            pcre_match = posixpath.join(
+            pcre_match = os.path.join(
                 "/",
                 self._get_save_path().replace(".", "[.]"),
                 f"deed[.]{pcre}(?:[.]html)?",
@@ -696,11 +697,10 @@ class Tool(models.Model):
             result.append("cc-zero")
         else:
             for unit_part in self.unit.split("-"):
-                if unit_part in ["by", "nc", "nd", "sa"]:
-                    if unit_part == "nc":
-                        result.append(self.nc_symbol)
-                    else:
-                        result.append(f"cc-{unit_part}")
+                if unit_part == "nc":
+                    result.append(self.nc_symbol)
+                elif unit_part in ["by", "nd", "sa"]:
+                    result.append(f"cc-{unit_part}")
         return result
 
     @property

--- a/legal_tools/tests/test_models.py
+++ b/legal_tools/tests/test_models.py
@@ -1024,8 +1024,58 @@ class ToolModelTest(TestCase):
             ).logos(),
         )
         self.assertEqual(
-            ["cc-logo", "cc-nc", "cc-sampling-plus"],
-            ToolFactory(unit="nc-sampling+", version="1.0").logos(),
+            ["cc-logo", "cc-by", "cc-nc-eu"],
+            ToolFactory(
+                unit="by-nc",
+                version="3.0",
+                jurisdiction_code="fr",
+                prohibits_commercial_use=True,
+                requires_share_alike=False,
+                permits_derivative_works=True,
+            ).logos(),
+        )
+        self.assertEqual(
+            ["cc-logo", "cc-by", "cc-nc-jp"],
+            ToolFactory(
+                unit="by-nc",
+                version="2.1",
+                jurisdiction_code="jp",
+                prohibits_commercial_use=True,
+                requires_share_alike=False,
+                permits_derivative_works=True,
+            ).logos(),
+        )
+        self.assertEqual(
+            ["cc-logo", "cc-nc-eu", "cc-sampling-plus"],
+            ToolFactory(
+                unit="nc-sampling+",
+                version="1.0",
+                jurisdiction_code="de",
+            ).logos(),
+        )
+        self.assertEqual(
+            "cc-nc-eu",
+            ToolFactory(unit="by-nc", jurisdiction_code="es").nc_symbol,
+        )
+        self.assertEqual(
+            "cc-nc-jp",
+            ToolFactory(unit="by-nc", jurisdiction_code="jp").nc_symbol,
+        )
+        self.assertEqual(
+            "cc-nc",
+            ToolFactory(unit="by-nc", jurisdiction_code="us").nc_symbol,
+        )
+        self.assertEqual(
+            "cc-nc",
+            ToolFactory.build(
+                unit="by-nc", jurisdiction_code=""
+            ).nc_symbol,
+        )
+        self.assertEqual(
+            "cc-nc",
+            ToolFactory.build(
+                unit="by-nc", jurisdiction_code="unknown_xyz"
+            ).nc_symbol,
         )
         self.assertEqual(
             ["cc-logo", "cc-nd"],

--- a/templates/includes/deed_body_licenses.html
+++ b/templates/includes/deed_body_licenses.html
@@ -72,7 +72,7 @@
   {% endif %}
 
   {% if tool.prohibits_commercial_use %}
-    <li class="cc-nc">
+    <li class="{{ tool.nc_symbol }}">
       <strong>{% trans "NonCommercial" %}</strong> &mdash;
       {% blocktrans %}You may not use the material for <a href="#ref-commercial-purposes" id="src-commercial-purposes">commercial purposes</a>.{% endblocktrans %}
     </li>


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #74 by @aldenstpage

## Description
<!-- Concisely describe what the pull request does. -->
Ported NonCommercial deeds for Euro and Yen jurisdictions (such as France, Germany, Spain, and Japan) were falling back to the default dollar NC icon instead of displaying their localized currency symbols.

The static assets in `cc-icons.svg` already contain `#cc-nc-eu` and `#cc-nc-jp`, and `i18n/utils.py` defines `JURISDICTION_CURRENCY_LOOKUP`. However, `Tool.logos()` hardcoded `cc-nc`, `deed_body_licenses.html` used a fixed class name, and `deed.css` was missing `:before` rules for the Euro and Yen classes.

This PR updates `legal_tools/models.py` by adding an `nc_symbol` property on `Tool` that resolves `cc-nc-eu` or `cc-nc-jp` using `JURISDICTION_CURRENCY_LOOKUP`, falling back to `cc-nc` for unported or non-EU/JP tools. `Tool.logos()` was updated to use this property. `templates/includes/deed_body_licenses.html` now uses `class="{{ tool.nc_symbol }}"`, and `:before` background-image rules were added in `deed.css` for `.cc-nc-eu` and `.cc-nc-jp`.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
- Uses existing `JURISDICTION_CURRENCY_LOOKUP` to infer currency symbols.
- Resolves SVG symbols `#cc-nc-eu` and `#cc-nc-jp` dynamically.
- Gracefully defaults to `#cc-nc` for unported licenses and unspecified jurisdictions.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
- Run `python manage.py test legal_tools.tests.test_models` to verify the added tests for Euro, Yen, standard dollar, and fallback handling (empty, None, and unknown jurisdiction codes) all pass cleanly.
- Run `flake8` to ensure code quality.

<!-- ## Screenshots -->
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
