### PR TITLE
Add copy button for canonical URL on deed page

### DIFF
--- a/cc_legal_tools/static/cc-legal-tools/base.css
+++ b/cc_legal_tools/static/cc-legal-tools/base.css
@@ -200,6 +200,17 @@ main > aside > nav ul > li {
 .cc-legal-tools article.canonical-url a {
   font-family: monospace;
 }
+.cc-legal-tools article.canonical-url button.copy-canonical-url {
+  margin-left: 0.6em;
+  padding: 0.15em 0.7em;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.85em;
+  color: #232323;
+  background: #fff;
+  border: 1px solid #999;
+  border-radius: 4px;
+}
 .cc-legal-tools .tool-meta .formats ul {
   list-style: none;
   display: inline-flex;

--- a/cc_legal_tools/static/cc-legal-tools/copy-canonical-url.js
+++ b/cc_legal_tools/static/cc-legal-tools/copy-canonical-url.js
@@ -1,0 +1,13 @@
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll(".copy-canonical-url").forEach(function (button) {
+    button.addEventListener("click", function () {
+      navigator.clipboard.writeText(button.dataset.url).then(function () {
+        var original = button.textContent;
+        button.textContent = "Copied!";
+        setTimeout(function () {
+          button.textContent = original;
+        }, 1500);
+      });
+    });
+  });
+});

--- a/templates/deed.html
+++ b/templates/deed.html
@@ -41,7 +41,9 @@
 <div class="meta-box">
 <article class="canonical-url">
 <h2>{% trans "Canonical URL" %}</h2>
-<a {% if lang.bidi %}dir="ltr"{% endif %} href="{{ canonical_url_cc}}">{{ canonical_url_cc }}</a>
+<a {% if lang.bidi %}dir="ltr"{% endif %} href="{{ canonical_url_cc }}">{{ canonical_url_cc }}</a>
+<button type="button" class="copy-canonical-url" data-url="{{ canonical_url_cc }}">{% trans "Copy" %}</button>
+<script src="{% static 'cc-legal-tools/copy-canonical-url.js' %}"></script>
 </article>
 </div>
 
@@ -360,6 +362,8 @@ else endorses your use of a work may be unlawful.
 </article>
 </li>
 {% endif %}
+
+
 
 </ul>
 </article>


### PR DESCRIPTION
Fixes

Fixes #594 by @mzeinstra

Description

Adds a "Copy" button next to the canonical URL on the deed page. Clicking it copies the canonical URL (e.g. https://creativecommons.org/licenses/by/4.0/) to the clipboard, so users no longer have to manually select the URL or strip the deed.en portion from the page address.

The button briefly shows "Copied!" as confirmation, then reverts.

Technical details
Added a <button class="copy-canonical-url"> next to the canonical URL link in templates/deed.html, passing the URL via a data-url attribute (using the existing canonical_url_cc template variable).
Added cc_legal_tools/static/cc-legal-tools/copy-canonical-url.js, which uses the navigator.clipboard API to copy the URL on click and provides brief visual feedback.
Added a small style rule for the button in base.css, scoped to .canonical-url. No changes were made to the existing canonical-URL box layout.
Tests

Manually tested locally: the button renders next to the canonical URL, clicking copies the correct URL to the clipboard, and the "Copied!" feedback appears and reverts. Existing layout is unchanged.


<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #[issue number] by @[issue author]

## Description
<!-- Concisely describe what the pull request does. -->

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [ ] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
